### PR TITLE
Fixed issue when screenValue is returned as null in the requst

### DIFF
--- a/component/authentication-endpoint/src/main/webapp/smsotp.jsp
+++ b/component/authentication-endpoint/src/main/webapp/smsotp.jsp
@@ -119,26 +119,18 @@
                                     <div class="row">
                                         <div class="span6">
                                              <!-- Token Pin -->
-                                             <div class="control-group">
-                                                <label class="control-label" for="password">
-                                                Enter the code sent to your mobile phone:</label>
-                                                 <%
-                                                     String order = request.getParameter("order");
-                                                     if(order != null) {
-                                                        if (order.equals("backward")) {
-                                                 %>
-                                                    <b> ******<%= request.getParameter("screenvalue") %></b>
-                                                 <%
-                                                     } else {
-                                                 %>
-                                                    <b><%= request.getParameter("screenvalue") %> ******</b>
-                                                 <%
-                                                    } } else {
-                                                 %>
-                                                 <b><%= request.getParameter("screenvalue") %></b>
-                                                 <% }  %>
-                                                <input type="password" id='OTPcode' name="OTPcode" class="input-xlarge"
-                                                size='30'/>
+                                             <% if (request.getParameter("screenvalue") != null) { %>
+                                              <div class="control-group">
+                                               <label class="control-label" for="password">
+                                               Enter the code sent to your mobile phone:<%=request.getParameter("screenvalue")%></label>
+                                               <input type="password" id='OTPcode' name="OTPcode"
+                                               class="input-xlarge" size='30'/>
+                                               <% } else { %>
+                                               <div class="control-group">
+                                               <label class="control-label" for="password">Enter the code sent to your mobile phone:</label>
+                                               <input type="password" id='OTPcode' name="OTPcode"
+                                               class="input-xlarge" size='30'/>
+                                               <% } %>
                                              </div>
                                              <input type="hidden" name="sessionDataKey"
                                                 value='<%=request.getParameter("sessionDataKey")%>'/><br/>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -452,7 +452,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             if (!sendRESTCall(context, smsUrl, httpMethod, headerString, payload, httpResponse, mobileNumber, otpToken)) {
                 String retryParam;
                 context.setProperty(SMSOTPConstants.STATUS_CODE, SMSOTPConstants.UNABLE_SEND_CODE);
-                if (StringUtils.isNotEmpty(context.getProperty(SMSOTPConstants.ERROR_CODE).toString())) {
+                if (context.getProperty(SMSOTPConstants.ERROR_CODE) != null) {
                     retryParam = SMSOTPConstants.UNABLE_SEND_CODE_PARAM +
                             context.getProperty(SMSOTPConstants.ERROR_CODE).toString();
                 } else {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -465,10 +465,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 boolean isUserExists = FederatedAuthenticatorUtil.isUserExistInUserStore(username);
                 if (isUserExists) {
                     screenValue = getScreenAttribute(context, userRealm, tenantAwareUsername);
-                    if (screenValue != null && SMSOTPUtils.getDigitsOrder(context, getName()) != null) {
-                        url = url + SMSOTPConstants.SCREEN_VALUE + screenValue + SMSOTPConstants.ORDER_OF_DIGITS +
-                                SMSOTPUtils.getDigitsOrder(context, getName());
-                    } else {
+                    if (screenValue != null) {
                         url = url + SMSOTPConstants.SCREEN_VALUE + screenValue;
                     }
                 }
@@ -887,23 +884,31 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         String screenUserAttributeValue = null;
         String screenValue = null;
         int noOfDigits = 0;
-
+        int screenAttributeLength = 0;
+        String hiddenScreenValue;
         screenUserAttributeParam = SMSOTPUtils.getScreenUserAttribute(context, getName());
         if (screenUserAttributeParam != null) {
             screenUserAttributeValue = userRealm.getUserStoreManager()
                     .getUserClaimValue(username, screenUserAttributeParam, null);
-            noOfDigits = screenUserAttributeValue.length();
+            screenAttributeLength = screenUserAttributeValue.length();
         }
         if ((SMSOTPUtils.getNoOfDigits(context, getName())) != null) {
             noOfDigits = Integer.parseInt(SMSOTPUtils.getNoOfDigits(context, getName()));
         }
         if (screenUserAttributeValue != null) {
             if (SMSOTPConstants.BACKWARD.equals(SMSOTPUtils.getDigitsOrder(context, getName()))) {
-                int screenAttributeLength = screenUserAttributeValue.length();
                 screenValue = screenUserAttributeValue.substring(screenAttributeLength - noOfDigits,
                         screenAttributeLength);
+                hiddenScreenValue = screenUserAttributeValue.substring(0, screenAttributeLength - noOfDigits);
+                for (int i = 0; i < hiddenScreenValue.length(); i++) {
+                    screenValue = ("*").concat(screenValue);
+                }
             } else {
                 screenValue = screenUserAttributeValue.substring(0, noOfDigits);
+                hiddenScreenValue = screenUserAttributeValue.substring(noOfDigits, screenAttributeLength);
+                for (int i = 0; i < hiddenScreenValue.length(); i++) {
+                    screenValue = screenValue.concat("*");
+                }
             }
         }
         return screenValue;

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -558,11 +558,11 @@ public class SMSOTPAuthenticatorTest {
         when(SMSOTPUtils.getNoOfDigits(context, SMSOTPConstants.AUTHENTICATOR_NAME)).thenReturn("4");
 
         // with forward order
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"0778");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"0778******");
 
         // with backward order
         when(SMSOTPUtils.getDigitsOrder(context, SMSOTPConstants.AUTHENTICATOR_NAME)).thenReturn("backward");
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"5231");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"******5231");
     }
 
     @Test(expectedExceptions = {SMSOTPException.class})


### PR DESCRIPTION
## Purpose
When show the screenAttribute value in the UI, it shows "null" if the screenValue is returned as null in the request.

## Goals

## User stories

## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 JDK 1.8
ubuntu
## Learning
