### PR TITLE
Fix jstl issue of by providing correct dependencies

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -97,6 +97,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
                 <version>${wso2.json}</version>
             </dependency>
             <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>jstl</artifactId>
+                <version>${javax.servelet.jstl.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-lang.wso2</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.wso2.version}</version>


### PR DESCRIPTION
Resolved bellow error

[2019-08-02 10:34:33,801] ERROR {org.apache.catalina.core.StandardWrapperValve} -  Servlet.service() for servlet [jsp] in context with path [/smsotpauthenticationendpoint] threw exception [The absolute uri: http://java.sun.com/jsp/jstl/fmt cannot be resolved in either web.xml or the jar files deployed with this application] with root cause
org.apache.jasper.JasperException: The absolute uri: http://java.sun.com/jsp/jstl/fmt cannot be resolved in either web.xml or the jar files deployed with this application
	at org.apache.jasper.compiler.DefaultErrorHandler.jspError(DefaultErrorHandler.java:56)
	at org.apache.jasper.compiler.ErrorDispatcher.dispatch(ErrorDispatcher.java:445)
	at org.apache.jasper.compiler.ErrorDispatcher.jspError(ErrorDispatcher.java:117)
	at org.apache.jasper.compiler.TagLibraryInfoImpl.generateTLDLocation(TagLibraryInfoImpl.java:325)
	at org.apache.jasper.compiler.TagLibraryInfoImpl.<init>(TagLibraryInfoImpl.java:154)
	at org.apache.jasper.compiler.Parser.parseTaglibDirective(Parser.java:419)
	at org.apache.jasper.compiler.Parser.parseDirective(Parser.java:484)
	at org.apache.jasper.compiler.Parser.parseElements(Parser.java:1421)
	at org.apache.jasper.compiler.Parser.parse(Parser.java:138)
	at org.apache.jasper.compiler.ParserController.doParse(ParserController.java:242)
	at org.apache.jasper.compiler.ParserController.parse(ParserController.java:102)
	at org.apache.jasper.compiler.Compiler.generateJava(Compiler.java:199)
	at org.apache.jasper.compiler.Compiler.compile(Compiler.java:374)
	at org.apache.jasper.compiler.Compiler.compile(Compiler.java:354)
	at org.apache.jasper.compiler.Compiler.compile(Compiler.java:341)
	