### PR TITLE
Remove jstl dependencies and usages as localization is not used.

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -97,10 +97,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
             <scope>provided</scope>

--- a/component/authentication-endpoint/src/main/webapp/mobile.jsp
+++ b/component/authentication-endpoint/src/main/webapp/mobile.jsp
@@ -20,9 +20,9 @@
 <%@page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
-<fmt:bundle basename="org.wso2.carbon.identity.application.authentication.endpoint.i18n.Resources">
+
+
 
     <%
         request.getSession().invalidate();
@@ -171,4 +171,4 @@
         </script>
     </body>
     </html>
-</fmt:bundle>
+

--- a/component/authentication-endpoint/src/main/webapp/smsotp.jsp
+++ b/component/authentication-endpoint/src/main/webapp/smsotp.jsp
@@ -20,7 +20,7 @@
 <%@ page import="org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants" %>
 <%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
 
 <%
         request.getSession().invalidate();
@@ -193,3 +193,4 @@
     </script>
     </body>
     </html>
+

--- a/component/authentication-endpoint/src/main/webapp/smsotpError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/smsotpError.jsp
@@ -21,7 +21,6 @@
 <%@ page import="org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants" %>
 <%@page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ page import="static java.util.Base64.getDecoder" %>
 
 <%
@@ -151,3 +150,4 @@
     <script src="libs/bootstrap_3.3.5/js/bootstrap.min.js"></script>
     </body>
     </html>
+

--- a/pom.xml
+++ b/pom.xml
@@ -153,11 +153,6 @@
                 <version>${wso2.json}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>jstl</artifactId>
-                <version>${javax.servelet.jstl.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-lang.wso2</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.wso2.version}</version>


### PR DESCRIPTION
This is to avoid packing of jstl package to the internal WEB_INF/lib folder