### PR TITLE
Add account lock for SMS OTP

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -84,6 +84,11 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -136,6 +141,10 @@
                             javax.servlet.http,
                             org.wso2.carbon.extension.identity.helper.*;
                             version="${identity.extension.utils.import.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.exception;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -25,6 +25,7 @@ import java.util.ResourceBundle;
 
 public class SMSOTPConstants {
 
+    public static final String USER_IS_LOCKED = "17003";
     private static final String SMSOTP_PREFIX = "SMSOTP-";
     public static final String AUTHENTICATOR_NAME = "SMSOTP";
     public static final String AUTHENTICATOR_FRIENDLY_NAME = "SMS OTP";
@@ -40,6 +41,11 @@ public class SMSOTPConstants {
     public static final String MOBILE_CLAIM = "http://wso2.org/claims/mobile";
     public static final String SAVED_OTP_LIST = "http://wso2.org/claims/otpbackupcodes";
     public static final String USER_SMSOTP_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/smsotp_disabled";
+    public static final String SMS_OTP_FAIL_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
+    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM = "http://wso2.org/claims/identity/" +
+            "failedLoginLockoutCount";
+    public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
 
     public static final String SMS_URL = "sms_url";
     public static final String HTTP_METHOD = "http_method";
@@ -60,6 +66,8 @@ public class SMSOTPConstants {
     public static final String TOKEN_EXPIRY_TIME = "TokenExpiryTime";
     public static final String TOKEN_LENGTH = "TokenLength";
     public static final String USE_INTERNAL_ERROR_CODES = "UseInternalErrorCodes";
+    public static final String SHOW_AUTH_FAILURE_REASON = "ShowAuthFailureReason";
+    public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
 
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";
@@ -116,22 +124,30 @@ public class SMSOTPConstants {
     public static final String FEDERATED_MOBILE_ATTRIBUTE_KEY = "federatedMobileAttributeKey";
     public static final String IS_SEND_OTP_TO_FEDERATED_MOBILE = "SendOtpToFederatedMobile";
 
+    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
+    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+
+
     /**
      * Enums for error messages.
      */
     public enum ErrorMessage {
 
         CLIENT_BAD_REQUEST("60001", "Bad request. Please check the request and re-submit"),
-        CLIENT_UNAUTHORIZED("60002", "Unauthorized request. Server is not authorized to access the SMS Provider"),
+        CLIENT_UNAUTHORIZED("60002", "Unauthorized request. Server is not authorized to access the SMS " +
+                "Provider"),
         CLIENT_PAYMENT_REQUIRED("60003", "Payment requirement for the request."),
         CLIENT_FORBIDDEN("60004", "Server is permitted to access the SMS Provider URL."),
         CLIENT_NOT_FOUND("60005", "Not Found. Please note that SMS Provider resource is not found."),
-        CLIENT_METHOD_NOT_ALLOWED("60006", "Method Not Allowed. HTTP method used by the Server to connect SMS " +
-                "provider is allowed"),
-        CLIENT_NOT_ACCEPTABLE("60007", "Not Acceptable. Please note that the requested media type cannot be " +
-                "generated."), //406
+        CLIENT_METHOD_NOT_ALLOWED("60006", "Method Not Allowed. HTTP method used by the Server to " +
+                "connect SMS provider is allowed"),
+        CLIENT_NOT_ACCEPTABLE("60007", "Not Acceptable. Please note that the requested media type " +
+                "cannot be generated."), //406
         SERVER_INTERNAL_ERROR("65001", "Internal Error in the SMS Provider Server."),
-        SERVER_NOT_IMPLEMENTED("65002", "Not Implemented. SMS Provider Server cannot recognize the request method."),
+        SERVER_NOT_IMPLEMENTED("65002", "Not Implemented. SMS Provider Server cannot recognize the " +
+                "request method."),
         SERVER_BAD_GATEWAY("65003", "Bad Gateway or SMS Provider server overloaded."),
         SERVER_UNAVAILABLE("65004", "SMS Service unavailable or gateway time-out."),
         SERVER_TIMEOUT("65005", "Secondary gateway or SMS provider server time-out."),

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPAuthenticatorServiceComponent.java
@@ -25,6 +25,8 @@ import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.authenticator.smsotp.SMSOTPAuthenticator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.Hashtable;
@@ -37,6 +39,13 @@ import java.util.Hashtable;
  * @scr.reference name="RealmService"
  * interface="org.wso2.carbon.user.core.service.RealmService" cardinality="1..1"
  * policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ * @scr.reference name="IdentityGovernanceService"
+ * interface="org.wso2.carbon.identity.governance.IdentityGovernanceService" cardinality="1..1"
+ * policy="dynamic" bind="setIdentityGovernanceService" unbind="unsetIdentityGovernanceService"
+ * @scr.reference name="AccountLockService"
+ * interface="org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService"
+ * unbind="unsetAccountLockService"
  */
 public class SMSOTPAuthenticatorServiceComponent {
 
@@ -78,6 +87,20 @@ public class SMSOTPAuthenticatorServiceComponent {
     protected void unsetRealmService(RealmService realmService) {
         SMSOTPServiceDataHolder.getInstance().setRealmService(null);
     }
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(null);
+    }
 
+    protected void setIdentityGovernanceService(IdentityGovernanceService idpManager) {
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(idpManager);
+    }
+
+    protected void setAccountLockService(AccountLockService accountLockService) {
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(null);
+    }
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPServiceDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPServiceDataHolder.java
@@ -18,6 +18,8 @@ package org.wso2.carbon.identity.authenticator.smsotp.internal;
 
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 public class SMSOTPServiceDataHolder {
@@ -27,6 +29,8 @@ public class SMSOTPServiceDataHolder {
     private BundleContext bundleContext;
     private IdentityEventService identityEventService;
     private RealmService realmService;
+    private AccountLockService accountLockService;
+    private IdentityGovernanceService identityGovernanceService;
 
     private SMSOTPServiceDataHolder(){
 
@@ -59,5 +63,24 @@ public class SMSOTPServiceDataHolder {
 
     public void setRealmService(RealmService realmService) {
         this.realmService = realmService;
+    }
+
+    public IdentityGovernanceService getIdentityGovernanceService() {
+        if(identityGovernanceService == null) {
+            throw new RuntimeException("IdentityGovernanceService not available. Component is not started properly.");
+        }
+        return identityGovernanceService;
+    }
+
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+        this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public AccountLockService getAccountLockService() {
+        return accountLockService;
+    }
+
+    public void setAccountLockService(AccountLockService accountLockService) {
+        this.accountLockService = accountLockService;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,13 @@
                 <artifactId>org.wso2.carbon.identity.event</artifactId>
                 <version>${carbon.identity.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+                <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+                <version>${carbon.identity.account.lock.handler.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.smsotp</groupId>
                 <artifactId>org.wso2.carbon.extension.identity.authenticator.smsotp.connector</artifactId>
@@ -407,5 +414,8 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)
         </identity.extension.utils.import.version.range>
+        <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
> Introduce account locking for failed attempts with SMS OTP.

## Documentation
> A new claim has to be created `http://wso2.org/claims/identity/failedSmsOtpAttempts`.
> Following two config params are introduced. 

```
<AuthenticatorConfig name="SMSOTP" enabled="true">
        <Parameter name="ShowAuthFailureReason">true</Parameter>
        <Parameter name="EnableAccountLockingForFailedAttempts">ture</Parameter>
```
> `ShowAuthFailureReason` acts same as the basic authenticator, default is false.
`EnableAccountLockingForFailureAttempts` is to keep the backward compatibility, default is false.
