### PR TITLE
Improve account locking feature for SMS OTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -663,7 +663,12 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             url = url + SMSOTPConstants.SCREEN_VALUE + getScreenValue(context);
         }
         try {
-            if (isRetryEnabled) {
+            if (Boolean.parseBoolean(String.valueOf(context.getProperty(SMSOTPConstants.ACCOUNT_LOCKED))) &&
+                    SMSOTPUtils.isShowAuthFailureReason(context)) {
+                response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
+                        + SMSOTPUtils.isEnableResendCode(context) + SMSOTPConstants.ERROR_MESSAGE + SMSOTPConstants
+                        .ACCOUNT_LOCKED_ERROR);
+            } else if (isRetryEnabled) {
                 if (StringUtils.isNotEmpty((String) context.getProperty(SMSOTPConstants.TOKEN_EXPIRED))) {
                     response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
                             + SMSOTPUtils.isEnableResendCode(context) + SMSOTPConstants.ERROR_MESSAGE +
@@ -755,10 +760,19 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
+        boolean isLocalUser = SMSOTPUtils.isLocalUser(context);
+        if (authenticatedUser != null && isLocalUser && SMSOTPUtils.isAccountLocked(authenticatedUser)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Authentication failed since authenticated user: %s,  account is locked.",
+                        authenticatedUser));
+            }
+            context.setProperty(SMSOTPConstants.ACCOUNT_LOCKED, true);
+            throw new AuthenticationFailedException("User account is locked.");
+        }
         String userToken = request.getParameter(SMSOTPConstants.CODE);
         String contextToken = (String) context.getProperty(SMSOTPConstants.OTP_TOKEN);
-        AuthenticatedUser authenticatedUser = (AuthenticatedUser)
-                context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
         if (StringUtils.isEmpty(request.getParameter(SMSOTPConstants.CODE))) {
             throw new InvalidCredentialsException("Code cannot not be null");
         }
@@ -769,27 +783,17 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             throw new InvalidCredentialsException("Retrying to resend the OTP");
         }
 
-        try {
-            if (userToken.equals(contextToken)) {
-                processValidUserToken(context, authenticatedUser);
-            } else if (SMSOTPUtils.getBackupCode(context).equals("true")) {
-                checkWithBackUpCodes(context, userToken, authenticatedUser);
-            } else {
-                handleCodeMismatch(context);
-            }
-        } catch (AuthenticationFailedException e){
-            // Check whether account locking enabled for SMS OTP to keep backward compatibility
-            if (SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context)) {
-                handleSmsOtpVerificationFail(authenticatedUser);
-            }
-            throw e;
+        if (userToken.equals(contextToken)) {
+            processValidUserToken(context, authenticatedUser);
+        } else if (isLocalUser && "true".equals(SMSOTPUtils.getBackupCode(context))) {
+            checkWithBackUpCodes(context, userToken, authenticatedUser);
+        } else {
+            handleSmsOtpVerificationFail(context);
+            handleCodeMismatch(context);
         }
 
         // It reached here means the authentication was successful
-        // Check whether account locking enabled for SMS OTP to keep backward compatibility
-        if (SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context)) {
-            resetSmsOtpFailedAttempts(authenticatedUser);
-        }
+        resetSmsOtpFailedAttempts(context);
     }
 
     private void handleCodeMismatch(AuthenticationContext context) throws AuthenticationFailedException {
@@ -878,6 +882,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                             "backup codes");
                 }
                 context.setProperty(SMSOTPConstants.CODE_MISMATCH, true);
+                handleSmsOtpVerificationFail(context);
                 throw new AuthenticationFailedException("Verification Error due to Code " + userToken + " " +
                         "mismatch.", authenticatedUser);
             }
@@ -926,9 +931,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the user realm of the logged in user.
      *
-     * @param authenticatedUser
-     * @return the userRealm
-     * @throws AuthenticationFailedException
+     * @param authenticatedUser Authenticated user.
+     * @return The userRealm.
+     * @throws AuthenticationFailedException AuthenticationFailedException Exception on authentication failure.
      */
     private UserRealm getUserRealm(AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
 
@@ -1367,16 +1372,25 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     }
 
     /**
-     * Reset SMS OTP Failed Attempts count upon successful completion of the SMS OTP verification
+     * Reset SMS OTP Failed Attempts count upon successful completion of the SMS OTP verification.
      *
-     * @param authenticatedUser
-     * @throws AuthenticationFailedException
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException  AuthenticationFailedException Exception on authentication failure.
      */
-    private void resetSmsOtpFailedAttempts(AuthenticatedUser authenticatedUser)
-            throws AuthenticationFailedException {
+    private void resetSmsOtpFailedAttempts(AuthenticationContext context) throws AuthenticationFailedException {
 
+        /*
+        Check whether account locking enabled for SMS OTP to keep backward compatibility.
+        Account locking is not done for federated flows.
+         */
+        if (!SMSOTPUtils.isLocalUser(context) || !SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context)) {
+            return;
+        }
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
         Property[] connectorConfigs = SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
 
+        // Return if account lock handler is not enabled.
         for (Property connectorConfig : connectorConfigs) {
             if ((SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
                     !Boolean.parseBoolean(connectorConfig.getValue())) {
@@ -1384,79 +1398,94 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             }
         }
 
-        Map<String, String> updatedClaims = new HashMap<>();
-        updatedClaims.put(SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM, "0");
-        updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
-
+        String usernameWithDomain = IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+                authenticatedUser.getUserStoreDomain());
         try {
             UserRealm userRealm = getUserRealm(authenticatedUser);
             UserStoreManager userStoreManager = userRealm.getUserStoreManager();
-            userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
-                    authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+
+            // Avoid updating the claims if they are already zero.
+            String[] claimsToCheck = {SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM,
+                    SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM};
+            Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
+                    UserCoreConstants.DEFAULT_PROFILE);
+            String failedSmsOtpAttempts = userClaims.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM);
+            String failedLoginLockoutCount = userClaims.get(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
+
+            if (NumberUtils.isNumber(failedSmsOtpAttempts) && Integer.parseInt(failedSmsOtpAttempts) > 0 ||
+                    NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+                Map<String, String> updatedClaims = new HashMap<>();
+                updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+                updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+                userStoreManager
+                        .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+            }
         } catch (UserStoreException e) {
-            throw new AuthenticationFailedException("Failed to reset failed attempts count for user : " +
-                    authenticatedUser, e);
+            log.error("Error while resetting failed SMS OTP attempts", e);
+            String errorMessage =
+                    String.format("Failed to reset failed attempts count for user : %s.", authenticatedUser);
+            throw new AuthenticationFailedException(errorMessage, e);
         }
     }
 
     /**
-     * Execute account lock flow for OTP verification failures
+     * Execute account lock flow for OTP verification failures.
      *
-     * @param authenticatedUser
-     * @throws AuthenticationFailedException
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException Exception on authentication failure.
      */
-    private void handleSmsOtpVerificationFail(AuthenticatedUser authenticatedUser) throws
-            AuthenticationFailedException {
+    private void handleSmsOtpVerificationFail(AuthenticationContext context) throws AuthenticationFailedException {
 
-        if (SMSOTPUtils.isAccountLocked(authenticatedUser)) {
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
+
+        /*
+        Account locking is not done for federated flows.
+        Check whether account locking enabled for SMS OTP to keep backward compatibility.
+        No need to continue if the account is already locked.
+         */
+        if (!SMSOTPUtils.isLocalUser(context) || !SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context) ||
+                SMSOTPUtils.isAccountLocked(authenticatedUser)) {
             return;
         }
-
-        Property[] connectorConfigs = SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
-
         int maxAttempts = 0;
         long unlockTimePropertyValue = 0;
         double unlockTimeRatio = 1;
+
+        Property[] connectorConfigs = SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
         for (Property connectorConfig : connectorConfigs) {
-            if ((SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
-                    !Boolean.parseBoolean(connectorConfig.getValue())) {
-                return;
-            } else if (SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX.equals(connectorConfig.getName())
-                    && NumberUtils.isNumber(connectorConfig.getValue())) {
-                maxAttempts = Integer.parseInt(connectorConfig.getValue());
-            } else if (SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_TIME.equals(connectorConfig.getName())
-                    && NumberUtils.isNumber(connectorConfig.getValue())) {
-                unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
-            } else if (SMSOTPConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO.equals(connectorConfig.getName())
-                    && NumberUtils.isNumber(connectorConfig.getValue())) {
-                double value = Double.parseDouble(connectorConfig.getValue());
-                if (value > 0) {
-                    unlockTimeRatio = value;
-                }
+            switch (connectorConfig.getName()) {
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                    if (!Boolean.parseBoolean(connectorConfig.getValue())) {
+                        return;
+                    }
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        maxAttempts = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_TIME:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case SMSOTPConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        double value = Double.parseDouble(connectorConfig.getValue());
+                        if (value > 0) {
+                            unlockTimeRatio = value;
+                        }
+                    }
+                    break;
             }
         }
-
-        UserStoreManager userStoreManager;
-        Map<String, String> claimValues;
-        try {
-            UserRealm userRealm = getUserRealm(authenticatedUser);
-            userStoreManager = userRealm.getUserStoreManager();
-
-            claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
-                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
-                            SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM,
-                            SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
-                    UserCoreConstants.DEFAULT_PROFILE);
-
-        } catch (UserStoreException e) {
-            throw new AuthenticationFailedException("Failed to update user claims for user : " +
-                    authenticatedUser, e);
+        Map<String, String> claimValues = getUserClaimValues(authenticatedUser);
+        if (claimValues == null) {
+            claimValues = new HashMap<>();
         }
-
-
         int currentAttempts = 0;
-        if (NumberUtils.isNumber(claimValues.get(SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM))) {
-            currentAttempts = Integer.parseInt(claimValues.get(SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM));
+        if (NumberUtils.isNumber(claimValues.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            currentAttempts = Integer.parseInt(claimValues.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM));
         }
         int failedLoginLockoutCountValue = 0;
         if (NumberUtils.isNumber(claimValues.get(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
@@ -1467,32 +1496,57 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         Map<String, String> updatedClaims = new HashMap<>();
         if ((currentAttempts + 1) >= maxAttempts) {
             // Calculate the incremental unlock-time-interval in milli seconds.
-            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow (unlockTimeRatio,
+            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
                     failedLoginLockoutCountValue));
             // Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
             long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
             updatedClaims.put(SMSOTPConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM, "0");
+            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
             updatedClaims.put(SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
             updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
                     String.valueOf(failedLoginLockoutCountValue + 1));
-            try {
-                userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
-                        authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
-                throw new AuthenticationFailedException("User account is locked " + authenticatedUser.getUserName());
-            } catch (UserStoreException e) {
-                throw new AuthenticationFailedException("Failed to update user claims for user : " +
-                        authenticatedUser, e);
-            }
+            IdentityUtil.threadLocalProperties.get().put(SMSOTPConstants.ADMIN_INITIATED, false);
+            setUserClaimValues(authenticatedUser, updatedClaims);
+            String errorMessage = String.format("User account: %s is locked.", authenticatedUser.getUserName());
+            throw new AuthenticationFailedException(errorMessage);
         } else {
-            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAIL_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
-            try {
-                userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
-                        authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
-            } catch (UserStoreException e) {
-                throw new AuthenticationFailedException("Failed to update user claims for user : " +
-                        authenticatedUser, e);
-            }
+            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
+            setUserClaimValues(authenticatedUser, updatedClaims);
+        }
+    }
+
+    private Map<String, String> getUserClaimValues(AuthenticatedUser authenticatedUser)
+            throws AuthenticationFailedException {
+
+        Map<String, String> claimValues;
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
+                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+                            SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM,
+                            SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while reading user claims", e);
+            String errorMessage = String.format("Failed to read user claims for user : %s.", authenticatedUser);
+            throw new AuthenticationFailedException(errorMessage, e);
+        }
+        return claimValues;
+    }
+
+    private void setUserClaimValues(AuthenticatedUser authenticatedUser, Map<String, String> updatedClaims)
+            throws AuthenticationFailedException {
+
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+                    authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while updating user claims", e);
+            String errorMessage = String.format("Failed to update user claims for user : %s.", authenticatedUser);
+            throw new AuthenticationFailedException(errorMessage, e);
         }
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -41,9 +41,9 @@ public class SMSOTPConstants {
     public static final String MOBILE_CLAIM = "http://wso2.org/claims/mobile";
     public static final String SAVED_OTP_LIST = "http://wso2.org/claims/otpbackupcodes";
     public static final String USER_SMSOTP_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/smsotp_disabled";
-    public static final String SMS_OTP_FAIL_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
-    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM = "http://wso2.org/claims/identity/" +
-            "failedLoginLockoutCount";
+    public static final String SMS_OTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
+    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
+            "http://wso2.org/claims/identity/failedLoginLockoutCount";
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
 
@@ -113,7 +113,8 @@ public class SMSOTPConstants {
     public static final String BACKWARD = "backward";
     public static final String SCREEN_VALUE = "&screenvalue=";
     public static final String CODE_MISMATCH = "codeMismatch";
-    public static final String ORDER_OF_DIGITS = "&order=";
+    public static final String ACCOUNT_LOCKED = "accountLocked";
+    public static final String ACCOUNT_LOCKED_ERROR = "account.locked";
     public static final String TOKEN_VALIDITY_TIME = "tokenValidityTime";
     public static final String SENT_OTP_TOKEN_TIME = "sentOTPTokenTime";
     public static final String TOKEN_EXPIRED = "tokenExpired";
@@ -121,6 +122,7 @@ public class SMSOTPConstants {
     public static final String ATTRIBUTE_SMS_SENT_TO = "send-to" ;
     public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
     public static final String EVENT_NAME = "SMSOTP";
+    public static final String LOCAL_AUTHENTICATOR = "LOCAL";
     public static final String FEDERATED_MOBILE_ATTRIBUTE_KEY = "federatedMobileAttributeKey";
     public static final String IS_SEND_OTP_TO_FEDERATED_MOBILE = "SendOtpToFederatedMobile";
 
@@ -128,7 +130,7 @@ public class SMSOTPConstants {
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
     public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
-
+    public static final String ADMIN_INITIATED = "AdminInitiated";
 
     /**
      * Enums for error messages.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.extension.identity.helper.IdentityHelperConstants;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -514,5 +515,25 @@ public class SMSOTPUtils {
         }
 
         return connectorConfigs;
+    }
+
+    /**
+     * Check whether the user being authenticated via a local authenticator or not.
+     *
+     * @param context Authentication context.
+     * @return Whether the user being authenticated via a local authenticator.
+     */
+    public static boolean isLocalUser(AuthenticationContext context) {
+
+        Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+        if (stepConfigMap != null) {
+            for (StepConfig stepConfig : stepConfigMap.values()) {
+                if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep() &&
+                        StringUtils.equals(SMSOTPConstants.LOCAL_AUTHENTICATOR, stepConfig.getAuthenticatedIdP())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -457,15 +457,21 @@ public class SMSOTPAuthenticatorTest {
 
     @Test(expectedExceptions = {InvalidCredentialsException.class})
     public void testProcessAuthenticationResponseWithoutOTPCode() throws Exception {
+
+        mockStatic(SMSOTPUtils.class);
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("");
+        when(SMSOTPUtils.isLocalUser(context)).thenReturn(true);
         Whitebox.invokeMethod(smsotpAuthenticator, "processAuthenticationResponse",
                 httpServletRequest, httpServletResponse, context);
     }
 
     @Test(expectedExceptions = {InvalidCredentialsException.class})
     public void testProcessAuthenticationResponseWithResend() throws Exception {
+
+        mockStatic(SMSOTPUtils.class);
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("123456");
         when(httpServletRequest.getParameter(SMSOTPConstants.RESEND)).thenReturn("true");
+        when(SMSOTPUtils.isLocalUser(context)).thenReturn(true);
         Whitebox.invokeMethod(smsotpAuthenticator, "processAuthenticationResponse",
                 httpServletRequest, httpServletResponse, context);
     }
@@ -520,8 +526,9 @@ public class SMSOTPAuthenticatorTest {
         Property property = new Property();
         property.setName(SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE);
         property.setValue("true");
-        when(SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain())).thenReturn(new Property[]{property});
-
+        when(SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain()))
+                .thenReturn(new Property[]{property});
+        when(SMSOTPUtils.isLocalUser(context)).thenReturn(true);
         Whitebox.invokeMethod(smsotpAuthenticator, "processAuthenticationResponse",
                 httpServletRequest, httpServletResponse, context);
     }
@@ -577,6 +584,7 @@ public class SMSOTPAuthenticatorTest {
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testCheckWithInvalidBackUpCodes() throws Exception {
         mockStatic(IdentityTenantUtil.class);
+        mockStatic(SMSOTPUtils.class);
         context.setProperty(SMSOTPConstants.USER_NAME,"admin");
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);


### PR DESCRIPTION
## Purpose
Backport of https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/91
Account locking for SMS OTP was already included in this branch. Fixed the issues and improve the code according to the master branch.