### PR TITLE
Support account locking for SMS OTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -22,6 +22,7 @@ package org.wso2.carbon.identity.authenticator.smsotp;
 import org.apache.catalina.util.URLEncoder;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
@@ -42,9 +43,11 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.authenticator.smsotp.exception.SMSOTPException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -519,7 +522,12 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             url = url + SMSOTPConstants.SCREEN_VALUE + getScreenValue(context);
         }
         try {
-            if (isRetryEnabled) {
+            if (Boolean.parseBoolean(String.valueOf(context.getProperty(SMSOTPConstants.ACCOUNT_LOCKED))) &&
+                    SMSOTPUtils.isShowAuthFailureReason(context)) {
+                response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
+                        + SMSOTPUtils.isEnableResendCode(context) + SMSOTPConstants.ERROR_MESSAGE + SMSOTPConstants
+                        .ACCOUNT_LOCKED_ERROR);
+            } else if (isRetryEnabled) {
                 if (StringUtils.isNotEmpty((String) context.getProperty(SMSOTPConstants.TOKEN_EXPIRED))) {
                     response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
                             + SMSOTPUtils.isEnableResendCode(context) + SMSOTPConstants.ERROR_MESSAGE +
@@ -611,9 +619,20 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
+        boolean isLocalUser = SMSOTPUtils.isLocalUser(context);
+
+        if (authenticatedUser != null && isLocalUser && SMSOTPUtils.isAccountLocked(authenticatedUser)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Authentication failed since authenticated user: %s,  account is locked.",
+                        authenticatedUser));
+            }
+            context.setProperty(SMSOTPConstants.ACCOUNT_LOCKED, true);
+            throw new AuthenticationFailedException("User account is locked.");
+        }
         String userToken = request.getParameter(SMSOTPConstants.CODE);
         String contextToken = (String) context.getProperty(SMSOTPConstants.OTP_TOKEN);
-        AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
         if (StringUtils.isEmpty(request.getParameter(SMSOTPConstants.CODE))) {
             throw new InvalidCredentialsException("Code cannot not be null");
         }
@@ -623,6 +642,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             }
             throw new InvalidCredentialsException("Retrying to resend the OTP");
         }
+        boolean succeededAttempt = false;
         if (userToken.equals(contextToken)) {
             if ((context.getProperty(SMSOTPConstants.TOKEN_VALIDITY_TIME) != null) && StringUtils.
                     isNotEmpty(context.getProperty(SMSOTPConstants.TOKEN_VALIDITY_TIME).toString())) {
@@ -633,30 +653,43 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                     context.setSubject(authenticatedUser);
                 } else {
                     context.setProperty(SMSOTPConstants.TOKEN_EXPIRED, SMSOTPConstants.TOKEN_EXPIRED_VALUE);
+                    handleSmsOtpVerificationFail(context);
                     throw new AuthenticationFailedException("OTP code has expired");
                 }
             } else {
                 context.setSubject(authenticatedUser);
             }
-        } else if (SMSOTPUtils.getBackupCode(context).equals("true")) {
-            checkWithBackUpCodes(context, userToken, authenticatedUser);
+            succeededAttempt = true;
+        } else if (isLocalUser && "true".equals(SMSOTPUtils.getBackupCode(context))) {
+            succeededAttempt = checkWithBackUpCodes(context, userToken, authenticatedUser);
         } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Given otp code is a mismatch.");
+            }
             context.setProperty(SMSOTPConstants.CODE_MISMATCH, true);
-            throw new AuthenticationFailedException("Code mismatch");
         }
+        if (!succeededAttempt) {
+            handleSmsOtpVerificationFail(context);
+            throw new AuthenticationFailedException("Invalid code. Verification failed.");
+        }
+        // It reached here means the authentication was successful
+        resetSmsOtpFailedAttempts(context);
     }
 
     /**
      * If user forgets the mobile, then user can use the back up codes to authenticate the user.
+     * Check whether the entered code matches with a backup code.
      *
-     * @param context           the AuthenticationContext
-     * @param userToken         the userToken
-     * @param authenticatedUser the name of authenticatedUser
-     * @throws AuthenticationFailedException
+     * @param context           The AuthenticationContext.
+     * @param userToken         The userToken.
+     * @param authenticatedUser The authenticatedUser.
+     * @return True if the user entered code matches with a backup code.
+     * @throws AuthenticationFailedException If an error occurred while retrieving user claim for OTP list.
      */
-    private void checkWithBackUpCodes(AuthenticationContext context, String userToken,
-                                      AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
+    private boolean checkWithBackUpCodes(AuthenticationContext context, String userToken,
+                                         AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
 
+        boolean isMatchingToken = false;
         String[] savedOTPs = null;
         String username = context.getProperty(SMSOTPConstants.USER_NAME).toString();
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
@@ -677,13 +710,13 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 if (log.isDebugEnabled()) {
                     log.debug("The claim " + SMSOTPConstants.SAVED_OTP_LIST + " does not contain any values");
                 }
-                throw new AuthenticationFailedException("The claim " + SMSOTPConstants.SAVED_OTP_LIST +
-                        " does not contain any values");
+                return false;
             }
             if (isBackUpCodeValid(savedOTPs, userToken)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Found saved backup SMS OTP for user :" + authenticatedUser);
                 }
+                isMatchingToken = true;
                 context.setSubject(authenticatedUser);
                 savedOTPs = (String[]) ArrayUtils.removeElement(savedOTPs, userToken);
                 userRealm.getUserStoreManager().setUserClaimValue(tenantAwareUsername,
@@ -694,12 +727,12 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                             "backup codes");
                 }
                 context.setProperty(SMSOTPConstants.CODE_MISMATCH, true);
-                throw new AuthenticationFailedException("Verification Error due to Code " + userToken + " mismatch.");
             }
         } catch (UserStoreException e) {
             throw new AuthenticationFailedException("Cannot find the user claim for OTP list for user : " +
                     authenticatedUser, e);
         }
+        return isMatchingToken;
     }
 
     private boolean isBackUpCodeValid(String[] savedOTPs, String userToken) {
@@ -734,6 +767,30 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             }
         } catch (UserStoreException e) {
             throw new AuthenticationFailedException("Cannot find the user realm. ", e);
+        }
+        return userRealm;
+    }
+
+    /**
+     * Get the user realm of the logged in user.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @return The userRealm.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private UserRealm getUserRealm(AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
+
+        UserRealm userRealm = null;
+        try {
+            if (authenticatedUser != null) {
+                String tenantDomain = authenticatedUser.getTenantDomain();
+                int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+                RealmService realmService = IdentityTenantUtil.getRealmService();
+                userRealm = realmService.getTenantUserRealm(tenantId);
+            }
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException(
+                    "Cannot find the user realm of user: " + authenticatedUser.getUserName(), e);
         }
         return userRealm;
     }
@@ -1025,5 +1082,186 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             }
         }
         return screenValue;
+    }
+
+    /**
+     * Reset SMS OTP Failed Attempts count upon successful completion of the SMS OTP verification.
+     *
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private void resetSmsOtpFailedAttempts(AuthenticationContext context) throws AuthenticationFailedException {
+
+        /*
+        Check whether account locking enabled for SMS OTP to keep backward compatibility.
+        Account locking is not done for federated flows.
+         */
+        if (!SMSOTPUtils.isLocalUser(context) || !SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context)) {
+            return;
+        }
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
+        Property[] connectorConfigs = SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
+
+        // Return if account lock handler is not enabled.
+        for (Property connectorConfig : connectorConfigs) {
+            if ((SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
+                    !Boolean.parseBoolean(connectorConfig.getValue())) {
+                return;
+            }
+        }
+
+        String usernameWithDomain = IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+                authenticatedUser.getUserStoreDomain());
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+
+            // Avoid updating the claims if they are already zero.
+            String[] claimsToCheck = {SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM,
+                    SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM};
+            Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
+                    UserCoreConstants.DEFAULT_PROFILE);
+            String failedSmsOtpAttempts = userClaims.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM);
+            String failedLoginLockoutCount = userClaims.get(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
+
+            if (NumberUtils.isNumber(failedSmsOtpAttempts) && Integer.parseInt(failedSmsOtpAttempts) > 0 ||
+                    NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+                Map<String, String> updatedClaims = new HashMap<>();
+                updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+                updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+                userStoreManager
+                        .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+            }
+        } catch (UserStoreException e) {
+            log.error("Error while resetting failed SMS OTP attempts", e);
+            String errorMessage =
+                    String.format("Failed to reset failed attempts count for user : %s.", authenticatedUser);
+            throw new AuthenticationFailedException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Execute account lock flow for OTP verification failures.
+     *
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private void handleSmsOtpVerificationFail(AuthenticationContext context) throws AuthenticationFailedException {
+
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
+
+        /*
+        Account locking is not done for federated flows.
+        Check whether account locking enabled for SMS OTP to keep backward compatibility.
+        No need to continue if the account is already locked.
+         */
+        if (!SMSOTPUtils.isLocalUser(context) || !SMSOTPUtils.isAccountLockingEnabledForSmsOtp(context) ||
+                SMSOTPUtils.isAccountLocked(authenticatedUser)) {
+            return;
+        }
+        int maxAttempts = 0;
+        long unlockTimePropertyValue = 0;
+        double unlockTimeRatio = 1;
+
+        Property[] connectorConfigs = SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain());
+        for (Property connectorConfig : connectorConfigs) {
+            switch (connectorConfig.getName()) {
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                    if (!Boolean.parseBoolean(connectorConfig.getValue())) {
+                        return;
+                    }
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        maxAttempts = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_TIME:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case SMSOTPConstants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        double value = Double.parseDouble(connectorConfig.getValue());
+                        if (value > 0) {
+                            unlockTimeRatio = value;
+                        }
+                    }
+                    break;
+            }
+        }
+        Map<String, String> claimValues = getUserClaimValues(authenticatedUser);
+        if (claimValues == null) {
+            claimValues = new HashMap<>();
+        }
+        int currentAttempts = 0;
+        if (NumberUtils.isNumber(claimValues.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            currentAttempts = Integer.parseInt(claimValues.get(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM));
+        }
+        int failedLoginLockoutCountValue = 0;
+        if (NumberUtils.isNumber(claimValues.get(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
+            failedLoginLockoutCountValue =
+                    Integer.parseInt(claimValues.get(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
+        }
+
+        Map<String, String> updatedClaims = new HashMap<>();
+        if ((currentAttempts + 1) >= maxAttempts) {
+            // Calculate the incremental unlock-time-interval in milli seconds.
+            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+                    failedLoginLockoutCountValue));
+            // Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
+            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+            updatedClaims.put(SMSOTPConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            updatedClaims.put(SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+            updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+                    String.valueOf(failedLoginLockoutCountValue + 1));
+            IdentityUtil.threadLocalProperties.get().put(SMSOTPConstants.ADMIN_INITIATED, false);
+            setUserClaimValues(authenticatedUser, updatedClaims);
+            String errorMessage = String.format("User account: %s is locked.", authenticatedUser.getUserName());
+            throw new AuthenticationFailedException(errorMessage);
+        } else {
+            updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
+            setUserClaimValues(authenticatedUser, updatedClaims);
+        }
+    }
+
+    private Map<String, String> getUserClaimValues(AuthenticatedUser authenticatedUser)
+            throws AuthenticationFailedException {
+
+        Map<String, String> claimValues;
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
+                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+                            SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM,
+                            SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while reading user claims of user: " + authenticatedUser.getUserName(), e);
+            String errorMessage =
+                    String.format("Failed to read user claims for user : %s.", authenticatedUser.getUserName());
+            throw new AuthenticationFailedException(errorMessage, e);
+        }
+        return claimValues;
+    }
+
+    private void setUserClaimValues(AuthenticatedUser authenticatedUser, Map<String, String> updatedClaims)
+            throws AuthenticationFailedException {
+
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+                    authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while updating user claims of user: " + authenticatedUser.getUserName(), e);
+            String errorMessage =
+                    String.format("Failed to update user claims for user : %s.", authenticatedUser.getUserName());
+            throw new AuthenticationFailedException(errorMessage, e);
+        }
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -36,6 +36,11 @@ public class SMSOTPConstants {
     public static final String SAVED_OTP_LIST = "http://wso2.org/claims/otpbackupcodes";
     public static final String USER_SMSOTP_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/smsotp_disabled";
     public static final String BACKUP_CODES_SEPARATOR = ",";
+    public static final String SMS_OTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
+    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
+            "http://wso2.org/claims/identity/failedLoginLockoutCount";
+    public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
 
     public static final String SMS_URL = "sms_url";
     public static final String HTTP_METHOD = "http_method";
@@ -53,6 +58,9 @@ public class SMSOTPConstants {
     public static final String IS_ENABLE_ALPHANUMERIC_TOKEN = "EnableAlphanumericToken";
     public static final String TOKEN_EXPIRY_TIME = "TokenExpiryTime";
     public static final String TOKEN_LENGTH = "TokenLength";
+    public static final String SHOW_AUTH_FAILURE_REASON = "ShowAuthFailureReason";
+    public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+
 
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";
@@ -94,10 +102,17 @@ public class SMSOTPConstants {
     public static final String BACKWARD = "backward";
     public static final String SCREEN_VALUE = "&screenvalue=";
     public static final String CODE_MISMATCH = "codeMismatch";
-    public static final String ORDER_OF_DIGITS = "&order=";
+    public static final String ACCOUNT_LOCKED = "accountLocked";
+    public static final String ACCOUNT_LOCKED_ERROR = "account.locked";
     public static final String TOKEN_VALIDITY_TIME = "tokenValidityTime";
     public static final String SENT_OTP_TOKEN_TIME = "sentOTPTokenTime";
     public static final String TOKEN_EXPIRED = "tokenExpired";
     public static final String TOKEN_EXPIRED_VALUE = "token.expired";
+    public static final String LOCAL_AUTHENTICATOR = "LOCAL";
 
+    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
+    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+    public static final String ADMIN_INITIATED = "AdminInitiated";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPAuthenticatorServiceComponent.java
@@ -24,12 +24,20 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.authenticator.smsotp.SMSOTPAuthenticator;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.Hashtable;
 
 /**
  * @scr.component name="identity.application.authenticator.SMSOTP.component" immediate="true"
+ * @scr.reference name="IdentityGovernanceService"
+ * interface="org.wso2.carbon.identity.governance.IdentityGovernanceService" cardinality="1..1"
+ * policy="dynamic" bind="setIdentityGovernanceService" unbind="unsetIdentityGovernanceService"
+ * @scr.reference name="AccountLockService"
+ * interface="org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService" unbind="unsetAccountLockService
  */
 public class SMSOTPAuthenticatorServiceComponent {
 
@@ -72,4 +80,23 @@ public class SMSOTPAuthenticatorServiceComponent {
         SMSOTPAuthenticatorServiceComponent.realmService = null;
     }
 
+    protected void setIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(idpManager);
+    }
+
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(null);
+    }
+
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(null);
+    }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPServiceDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/internal/SMSOTPServiceDataHolder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.authenticator.smsotp.internal;
+
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+
+public class SMSOTPServiceDataHolder {
+
+    private static volatile SMSOTPServiceDataHolder smsOTPServiceDataHolder = new SMSOTPServiceDataHolder();
+
+    private AccountLockService accountLockService;
+    private IdentityGovernanceService identityGovernanceService;
+
+    private SMSOTPServiceDataHolder() {
+
+    }
+
+    public static SMSOTPServiceDataHolder getInstance() {
+
+        return smsOTPServiceDataHolder;
+    }
+
+    public IdentityGovernanceService getIdentityGovernanceService() {
+
+        if (identityGovernanceService == null) {
+            throw new RuntimeException("IdentityGovernanceService not available. Component is not started properly.");
+        }
+        return identityGovernanceService;
+    }
+
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public AccountLockService getAccountLockService() {
+
+        return accountLockService;
+    }
+
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
             <artifactId>encoder</artifactId>
             <version>${encoder.wso2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
+            <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
+            <version>${carbon.identity.account.lock.handler.version}</version>
+        </dependency>
     </dependencies>
     <scm>
         <connection>scm:git:https://github.com/wso2-extensions/identity-outbound-auth-sms-otp.git</connection>
@@ -396,5 +401,8 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8, 2.0.0)
         </identity.extension.utils.import.version.range>
+        <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        </carbon.identity.account.lock.handler.imp.pkg.version.range>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Support account locking for SMS OTP
Backport https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/91 and https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/95