### PR TITLE
Prompt an error page when user account is locked

### DIFF
--- a/component/authentication-endpoint/src/main/webapp/smsotpError.jsp
+++ b/component/authentication-endpoint/src/main/webapp/smsotpError.jsp
@@ -55,6 +55,12 @@
                     errorMessage = "The code entered is expired. Authentication Failed!";
                 } else if (errorMessage.equalsIgnoreCase(SMSOTPConstants.SEND_OTP_DIRECTLY_DISABLE_MSG)) {
                     errorMessage = "User not found in the directory. Cannot proceed further without SMS OTP authentication.";
+                } else if (errorMessage.equalsIgnoreCase(SMSOTPConstants.ACCOUNT_LOCKED_ERROR)) {
+                    errorMessage = "User account is locked. Please retry later.";
+                    String unlockTime = request.getParameter("unlockTime");
+                    if (unlockTime != null) {
+                      errorMessage = String.format("User account is locked. Please retry after %s minutes.", unlockTime);
+                    }
                 }
             }
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -517,16 +517,27 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
 
         boolean isRetryEnabled = SMSOTPUtils.isRetryEnabled(context);
         String loginPage = getLoginPage(context);
+        AuthenticatedUser authenticatedUser =
+                (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
         String url = getURL(loginPage, queryParams);
         if (StringUtils.isNotEmpty(getScreenValue(context))) {
             url = url + SMSOTPConstants.SCREEN_VALUE + getScreenValue(context);
         }
         try {
-            if (Boolean.parseBoolean(String.valueOf(context.getProperty(SMSOTPConstants.ACCOUNT_LOCKED))) &&
-                    SMSOTPUtils.isShowAuthFailureReason(context)) {
-                response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
-                        + SMSOTPUtils.isEnableResendCode(context) + SMSOTPConstants.ERROR_MESSAGE + SMSOTPConstants
-                        .ACCOUNT_LOCKED_ERROR);
+            if (SMSOTPUtils.isLocalUser(context) && SMSOTPUtils.isAccountLocked(authenticatedUser)) {
+                boolean showAuthFailureReason = SMSOTPUtils.isShowAuthFailureReason(context);
+                String retryParam;
+                if (showAuthFailureReason) {
+                    long unlockTime = getUnlockTimeInMilliSeconds(context);
+                    long timeToUnlock = unlockTime - System.currentTimeMillis();
+                    if (timeToUnlock > 0) {
+                        queryParams += "&unlockTime=" + Math.round((double) timeToUnlock / 1000 / 60);
+                    }
+                    retryParam = SMSOTPConstants.ERROR_USER_ACCOUNT_LOCKED;
+                } else {
+                    retryParam = SMSOTPConstants.RETRY_PARAMS;
+                }
+                redirectToErrorPage(response, context, queryParams, retryParam);
             } else if (isRetryEnabled) {
                 if (StringUtils.isNotEmpty((String) context.getProperty(SMSOTPConstants.TOKEN_EXPIRED))) {
                     response.sendRedirect(url + SMSOTPConstants.RESEND_CODE
@@ -1262,6 +1273,46 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             String errorMessage =
                     String.format("Failed to update user claims for user : %s.", authenticatedUser.getUserName());
             throw new AuthenticationFailedException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Get user account unlock time in milli seconds. If no value configured for unlock time user claim, return 0.
+     *
+     * @param context The authenticated context.
+     * @return User account unlock time in milli seconds. If no value is configured return 0.
+     * @throws AuthenticationFailedException If an error occurred while getting the user unlock time.
+     */
+    private long getUnlockTimeInMilliSeconds(AuthenticationContext context) throws AuthenticationFailedException {
+
+        String username = context.getProperty(SMSOTPConstants.USER_NAME).toString();
+        String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
+        try {
+            UserRealm userRealm = getUserRealm(username);
+            if (userRealm == null) {
+                throw new AuthenticationFailedException("UserRealm is null for user: " + username);
+            }
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            if (userStoreManager == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("userStoreManager is null for user realm: " + userRealm);
+                }
+                throw new AuthenticationFailedException("userStoreManager is null for user realm: " + userRealm);
+            }
+            Map<String, String> claimValues = userStoreManager
+                    .getUserClaimValues(tenantAwareUsername, new String[]{SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM},
+                            null);
+            if (claimValues.get(SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM) == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("No value configured for claim: %s, of user: %s",
+                            SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM, username));
+                }
+                return 0;
+            }
+            return Long.parseLong(claimValues.get(SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM));
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("Cannot find the user claim for unlock time for user: " + username,
+                    e);
         }
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -58,7 +58,7 @@ public class SMSOTPConstants {
     public static final String IS_ENABLE_ALPHANUMERIC_TOKEN = "EnableAlphanumericToken";
     public static final String TOKEN_EXPIRY_TIME = "TokenExpiryTime";
     public static final String TOKEN_LENGTH = "TokenLength";
-    public static final String SHOW_AUTH_FAILURE_REASON = "ShowAuthFailureReason";
+    public static final String SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
 
 
@@ -103,7 +103,7 @@ public class SMSOTPConstants {
     public static final String SCREEN_VALUE = "&screenvalue=";
     public static final String CODE_MISMATCH = "codeMismatch";
     public static final String ACCOUNT_LOCKED = "accountLocked";
-    public static final String ACCOUNT_LOCKED_ERROR = "account.locked";
+    public static final String ACCOUNT_LOCKED_ERROR = "user.account.locked";
     public static final String TOKEN_VALIDITY_TIME = "tokenValidityTime";
     public static final String SENT_OTP_TOKEN_TIME = "sentOTPTokenTime";
     public static final String TOKEN_EXPIRED = "tokenExpired";
@@ -114,5 +114,6 @@ public class SMSOTPConstants {
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
     public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+    public static final String ERROR_USER_ACCOUNT_LOCKED = "&authFailure=true&authFailureMsg=user.account.locked";
     public static final String ADMIN_INITIATED = "AdminInitiated";
 }


### PR DESCRIPTION
## Purpose
Resolves: wso2/product-is#8600 
Backported https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/97 and https://github.com/wso2-support/identity-apps/pull/18/