### PR TITLE
Fix issue of including leading plus sign in phone number in SMSOTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1266,7 +1266,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 }
             }
             String contentType = (String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE);
-            if (StringUtils.isNotBlank(contentType) && httpMethod.equals(SMSOTPConstants.POST_METHOD) &&
+            if (StringUtils.isNotBlank(contentType) && SMSOTPConstants.POST_METHOD.equals(httpMethod) &&
                     (SMSOTPConstants.JSON_CONTENT_TYPE).equals(contentType.trim())) {
                 receivedMobileNumber = mobile;
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1261,8 +1261,10 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 if (headerElements.length > 1) {
                     headerElementProperties.put(headerElements[0], headerElements[1]);
                 } else {
-                    log.info("Either header name or value not found. Hence not adding header which contains " +
-                            headerElements[0]);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Either header name or value not found. Hence not adding header which contains " +
+                                headerElements[0]);
+                    }
                 }
             }
             String contentType = (String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1248,8 +1248,34 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         HttpURLConnection httpConnection;
         boolean connection;
         String smsMessage = SMSOTPConstants.SMS_MESSAGE;
-        String encodedMobileNo = URLEncoder.encode(mobile, CHAR_SET_UTF_8);
-        smsUrl = smsUrl.replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg",
+        String[] headerArray;
+        String receivedMobileNumber = URLEncoder.encode(mobile, CHAR_SET_UTF_8);
+        HashMap<String, Object> headerElementProperties = new HashMap<>();
+        if (StringUtils.isNotEmpty(headerString)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Processing HTTP headers since header string is available");
+            }
+            headerArray = headerString.split(",");
+            for (String header : headerArray) {
+                String[] headerElements = header.split(":");
+                if (headerElements.length > 1) {
+                    headerElementProperties.put(headerElements[0], headerElements[1]);
+                } else {
+                    log.info("Either header name or value not found. Hence not adding header which contains " +
+                            headerElements[0]);
+                }
+            }
+            String contentType = (String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE);
+            if (StringUtils.isNotBlank(contentType) && httpMethod.equals(SMSOTPConstants.POST_METHOD) &&
+                    (SMSOTPConstants.JSON_CONTENT_TYPE).equals(contentType.trim())) {
+                receivedMobileNumber = mobile;
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("No configured headers found. Header string is empty");
+            }
+        }
+        smsUrl = smsUrl.replaceAll("\\$ctx.num", receivedMobileNumber).replaceAll("\\$ctx.msg",
                 smsMessage.replaceAll("\\s", "+") + otpToken);
         URL smsProviderUrl = null;
         try {
@@ -1266,12 +1292,12 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         String subUrl = smsProviderUrl.getProtocol();
         if (subUrl.equals(SMSOTPConstants.HTTPS)) {
             httpConnection = (HttpsURLConnection) smsProviderUrl.openConnection();
-            connection = getConnection(httpConnection, context, headerString, payload, httpResponse, encodedMobileNo,
-                    smsMessage, otpToken, httpMethod);
+            connection = getConnection(httpConnection, context, headerString, payload, httpResponse,
+                    receivedMobileNumber, smsMessage, otpToken, httpMethod);
         } else {
             httpConnection = (HttpURLConnection) smsProviderUrl.openConnection();
-            connection = getConnection(httpConnection, context, headerString, payload, httpResponse, encodedMobileNo,
-                    smsMessage, otpToken, httpMethod);
+            connection = getConnection(httpConnection, context, headerString, payload, httpResponse,
+                    receivedMobileNumber, smsMessage, otpToken, httpMethod);
         }
         return connection;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -72,6 +72,9 @@ public class SMSOTPConstants {
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";
 
+    public static final String CONTENT_TYPE = "Content-Type";
+    public static final String JSON_CONTENT_TYPE = "application/json";
+
     public static final String SMSOTP_AUTHENTICATION_ENDPOINT_URL = "SMSOTPAuthenticationEndpointURL";
     public static final String SMSOTP_AUTHENTICATION_ERROR_PAGE_URL = "SMSOTPAuthenticationEndpointErrorPage";
 


### PR DESCRIPTION
## Purpose
This PR will fix the issue when URL encoding the POST body passing to the SMS gateway causes failing the requests sent to SMS providers.
Resolves: https://github.com/wso2/product-is/issues/9727

## Approach
Here the encoding of the mobile number is decided upon below two points.

- Content-Type header if present
- HTTP method

If the content-type is application/json and the HTTP method is POST, we will not do the URL encoding of the mobile number.