### PR TITLE
Validate added mobile number corresponding to SMS gateway

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -484,7 +484,27 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 String loginPage = SMSOTPUtils.getMobileNumberRequestPage(context);
                 try {
                     String url = getURL(loginPage, queryParams);
-                    response.sendRedirect(url);
+                    String mobileNumberPatternViolationError = SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_VIOLATED;
+                    String mobileNumberPattern =
+                            context.getAuthenticatorProperties().get(SMSOTPConstants.MOBILE_NUMBER_REGEX);
+                    if (StringUtils.isNotEmpty(mobileNumberPattern)) {
+                        // Check for regex is violation error message configured in idp configuration.
+                        if (StringUtils.isNotEmpty(context.getAuthenticatorProperties()
+                                .get(SMSOTPConstants.MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE))) {
+                            mobileNumberPatternViolationError = context.getAuthenticatorProperties()
+                                    .get(SMSOTPConstants.MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE);
+                        }
+                        // Send the response with encoded regex pattern and error message.
+                        response.sendRedirect(FrameworkUtils
+                                .appendQueryParamsStringToUrl(url, SMSOTPConstants.MOBILE_NUMBER_REGEX_PATTERN_QUERY +
+                                        getEncoder().encodeToString(context.getAuthenticatorProperties()
+                                                        .get(SMSOTPConstants.MOBILE_NUMBER_REGEX)
+                                                        .getBytes()) +
+                                        SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE_QUERY +
+                                        getEncoder().encodeToString(mobileNumberPatternViolationError.getBytes())));
+                    } else {
+                        response.sendRedirect(url);
+                    }
                 } catch (IOException e) {
                     throw new AuthenticationFailedException("Authentication failed!. An IOException occurred ", e);
                 }
@@ -724,7 +744,27 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 if (log.isDebugEnabled()) {
                     log.debug("Redirecting to mobile number request page : " + url);
                 }
-                response.sendRedirect(url);
+                String mobileNumberPatternViolationError = SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_VIOLATED;
+                String mobileNumberPattern =
+                        context.getAuthenticatorProperties().get(SMSOTPConstants.MOBILE_NUMBER_REGEX);
+                if (StringUtils.isNotEmpty(mobileNumberPattern)) {
+                    // Check for regex is violation error message configured in idp configuration.
+                    if (StringUtils.isNotEmpty(context.getAuthenticatorProperties()
+                            .get(SMSOTPConstants.MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE))) {
+                        mobileNumberPatternViolationError = context.getAuthenticatorProperties()
+                                .get(SMSOTPConstants.MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE);
+                    }
+                    // Send the response with encoded regex pattern and error message.
+                    response.sendRedirect(FrameworkUtils
+                            .appendQueryParamsStringToUrl(url, SMSOTPConstants.MOBILE_NUMBER_REGEX_PATTERN_QUERY +
+                                    getEncoder().encodeToString(context.getAuthenticatorProperties()
+                                            .get(SMSOTPConstants.MOBILE_NUMBER_REGEX)
+                                            .getBytes()) +
+                                    SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE_QUERY +
+                                    getEncoder().encodeToString(mobileNumberPatternViolationError.getBytes())));
+                } else {
+                    response.sendRedirect(url);
+                }
             } catch (IOException e) {
                 throw new AuthenticationFailedException("Authentication failed!. An IOException was caught. ", e);
             }
@@ -1002,7 +1042,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         headers.setDisplayOrder(2);
         configProperties.add(headers);
 
-        Property payload = new Property();
+        `Property payload = new Property();
         payload.setName(SMSOTPConstants.PAYLOAD);
         payload.setDisplayName("HTTP Payload");
         payload.setRequired(false);
@@ -1035,6 +1075,23 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         valuesToBeMasked.setDescription("Enter comma separated Values to be masked by * in the detailed error messages");
         valuesToBeMasked.setDisplayOrder(6);
         configProperties.add(valuesToBeMasked);
+
+        Property mobileNumberRegex = new Property();
+        mobileNumberRegex.setName(SMSOTPConstants.MOBILE_NUMBER_REGEX);
+        mobileNumberRegex.setDisplayName("Mobile Number Regex Pattern");
+        mobileNumberRegex.setRequired(false);
+        mobileNumberRegex.setDescription("Enter regex format to validate mobile number while capture and update " +
+                "mobile number.");
+        mobileNumberRegex.setDisplayOrder(7);
+        configProperties.add(mobileNumberRegex);
+
+        Property RegexFailureErrorMessage = new Property();
+        RegexFailureErrorMessage.setName(SMSOTPConstants.MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE);
+        RegexFailureErrorMessage.setDisplayName("Regex Violation Error Message");
+        RegexFailureErrorMessage.setRequired(false);
+        RegexFailureErrorMessage.setDescription("Enter error message for invalid mobile number patterns.");
+        RegexFailureErrorMessage.setDisplayOrder(8);
+        configProperties.add(RegexFailureErrorMessage);
 
         return configProperties;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -51,6 +51,9 @@ public class SMSOTPConstants {
     public static final String HEADERS = "headers";
     public static final String PAYLOAD = "payload";
     public static final String HTTP_RESPONSE = "http_response";
+    public static final String MOBILE_NUMBER_REGEX = "mobile_number_regex";
+    public static final String MOBILE_NUMBER_PATTERN_FAILURE_ERROR_MESSAGE =
+            "mobile_number_pattern_failure_error_message";
     public static final String SHOW_ERROR_INFO = "show_detailed_error_info";
     public static final String VALUES_TO_BE_MASKED_IN_ERROR_INFO = "values_to_be_masked";
     public static final String SMS_MESSAGE = "Verification Code: ";
@@ -87,6 +90,12 @@ public class SMSOTPConstants {
     public static final String RESEND = "resendCode";
     public static final String NAME_OF_AUTHENTICATORS = "authenticators=";
     public static final String RESEND_CODE = "&resendCode=";
+    public static final String MOBILE_NUMBER_REGEX_PATTERN_QUERY = "&mobileNumberRegexPattern=";
+    public static final String MOBILE_NUMBER_REGEX_PATTERN = "mobileNumberRegexPattern";
+    public static final String MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE_QUERY =
+            "&mobileNumberPatternPolicyFailureErrorMessage=";
+    public static final String MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE =
+            "mobileNumberPatternPolicyFailureErrorMessage";
     public static final String OTP_TOKEN = "otpToken";
     public static final String AUTHENTICATION = "authentication";
     public static final String BASIC = "basic";
@@ -127,6 +136,8 @@ public class SMSOTPConstants {
     public static final String LOCAL_AUTHENTICATOR = "LOCAL";
     public static final String FEDERATED_MOBILE_ATTRIBUTE_KEY = "federatedMobileAttributeKey";
     public static final String IS_SEND_OTP_TO_FEDERATED_MOBILE = "SendOtpToFederatedMobile";
+    public static final String MOBILE_NUMBER_PATTERN_POLICY_VIOLATED =
+            "Mobile number pattern policy violated";
 
     public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -666,6 +666,10 @@ public class SMSOTPAuthenticatorTest {
         configProperties.add(showErrorInfo);
         Property maskValues = new Property();
         configProperties.add(maskValues);
+        Property mobileNumberRegexPattern = new Property();
+        configProperties.add(mobileNumberRegexPattern);
+        Property mobileNumberPatternFailureErrorMessage = new Property();
+        configProperties.add(mobileNumberPatternFailureErrorMessage);
         Assert.assertEquals(configProperties.size(), smsotpAuthenticator.getConfigurationProperties().size());
     }
 


### PR DESCRIPTION
Partial Fix for : https://github.com/wso2/product-is/issues/10532

Logic : 
- Added two idp configurations in sms otp connector.
  - Error Regex
  - Error message for validation

Both strings will be sent to jsp page as encoded and validation will be handled in JSP pages, not in SMS OTP authenticator.

Please check the naming before  Approve the PR