### PR TITLE
Save mobile number after verifying the mobile number in multi step authentication

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -837,9 +837,6 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 String mobileNumber = SMSOTPUtils.getMobileNumberForUsername(username);
                 if (StringUtils.isEmpty(mobileNumber)) {
                     String tenantDomain = context.getTenantDomain();
-                    if (!tenantDomain.equals(SMSOTPConstants.SUPER_TENANT)) {
-                        IdentityHelperUtil.loadApplicationAuthenticationXMLFromRegistry(context, getName(), tenantDomain);
-                    }
                     Object verifiedMobileObject = context.getProperty(SMSOTPConstants.REQUEST_USER_MOBILE);
                     if (verifiedMobileObject != null) {
                         updateMobileNumberForUsername(context, request, username, tenantDomain);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -223,7 +223,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 }
                 redirectToMobileNoReqPage(response, context, queryParams);
             } else {
-                context.setProperty(SMSOTPConstants.REQUEST_USER_MOBILE, requestMobile);
+                context.setProperty(SMSOTPConstants.REQUESTED_USER_MOBILE, requestMobile);
                 mobileNumber = requestMobile;
             }
         }
@@ -356,7 +356,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 log.debug("Updating mobile number for user : " + username);
             }
             Map<String, String> attributes = new HashMap<>();
-            attributes.put(SMSOTPConstants.MOBILE_CLAIM, String.valueOf(context.getProperty(SMSOTPConstants.REQUEST_USER_MOBILE)));
+            attributes.put(SMSOTPConstants.MOBILE_CLAIM, String.valueOf(context.getProperty(SMSOTPConstants.REQUESTED_USER_MOBILE)));
             SMSOTPUtils.updateUserAttribute(MultitenantUtils.getTenantAwareUsername(username), attributes,
                     tenantDomain);
         }
@@ -837,7 +837,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 String mobileNumber = SMSOTPUtils.getMobileNumberForUsername(username);
                 if (StringUtils.isEmpty(mobileNumber)) {
                     String tenantDomain = context.getTenantDomain();
-                    Object verifiedMobileObject = context.getProperty(SMSOTPConstants.REQUEST_USER_MOBILE);
+                    Object verifiedMobileObject = context.getProperty(SMSOTPConstants.REQUESTED_USER_MOBILE);
                     if (verifiedMobileObject != null) {
                         updateMobileNumberForUsername(context, request, username, tenantDomain);
                     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -217,7 +217,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         String mobileNumber = SMSOTPUtils.getMobileNumberForUsername(username);
         if (StringUtils.isEmpty(mobileNumber)) {
             String requestMobile = request.getParameter(SMSOTPConstants.MOBILE_NUMBER);
-            if (StringUtils.isEmpty(requestMobile)) {
+            if (StringUtils.isBlank(requestMobile)) {
                 if (log.isDebugEnabled()) {
                     log.debug("User has not registered a mobile number: " + username);
                 }
@@ -843,7 +843,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                     }
                 }
             } catch (SMSOTPException e) {
-                throw new AuthenticationFailedException("Failed to get the parameters from authentication xml file. ", e);
+                throw new AuthenticationFailedException("Error in updating user mobile number. ", e);
             }
         }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -86,7 +86,7 @@ public class SMSOTPConstants {
     public static final String ERROR_PAGE = "smsotpauthenticationendpoint/smsotpError.jsp";
     public static final String MOBILE_NUMBER_REQ_PAGE = "MobileNumberRegPage";
     public static final String MOBILE_NUMBER = "MOBILE_NUMBER";
-    public static final String REQUEST_USER_MOBILE = "requestUserMobile";
+    public static final String REQUESTED_USER_MOBILE = "requestedUserMobile";
 
     public static final String RESEND = "resendCode";
     public static final String NAME_OF_AUTHENTICATORS = "authenticators=";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -86,6 +86,7 @@ public class SMSOTPConstants {
     public static final String ERROR_PAGE = "smsotpauthenticationendpoint/smsotpError.jsp";
     public static final String MOBILE_NUMBER_REQ_PAGE = "MobileNumberRegPage";
     public static final String MOBILE_NUMBER = "MOBILE_NUMBER";
+    public static final String REQUEST_USER_MOBILE = "requestUserMobile";
 
     public static final String RESEND = "resendCode";
     public static final String NAME_OF_AUTHENTICATORS = "authenticators=";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -203,7 +203,7 @@ public class SMSOTPAuthenticatorTest {
         when(SMSOTPUtils.getMobileNumberForUsername(anyString())).thenReturn("0775968325");
         Assert.assertEquals(Whitebox.invokeMethod(smsotpAuthenticator, "getMobileNumber",
                 httpServletRequest, httpServletResponse, any(AuthenticationContext.class),
-                "Kanapriya", "carbon.super", "queryParams"), "0775968325");
+                "Kanapriya", "queryParams"), "0775968325");
     }
 
     @Test


### PR DESCRIPTION
In the current implementation when multi step authentication is enabled and if the user has not specify the mobile number in the profile, it will prompt user to enter mobile number and then directly saves it. If user enters an
incorrect mobile there is no way for the user to change it himself. This implementation will save the mobile number once it is confirmed with the OTP code sends.

Resolves https://github.com/wso2/product-is/issues/10786