### PR TITLE
Version upgrade for newly created 2.0.16.3.x branch

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.smsotp</groupId>
         <artifactId>identity-outbound-auth-sms-otp</artifactId>
-        <version>2.0.16.3</version>
+        <version>2.0.16.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.smsotp.endpoint</artifactId>
-    <version>2.0.16.3</version>
+    <version>2.0.16.3.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>WSO2 Carbon - Identity Application Authentication SMSOTP Endpoint</name>
     <description>Identity Application Authentication SMSOTP Endpoint</description>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.smsotp</groupId>
         <artifactId>identity-outbound-auth-sms-otp</artifactId>
-        <version>2.0.16.3</version>
+        <version>2.0.16.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.smsotp.connector</artifactId>
-    <version>2.0.16.3</version>
+    <version>2.0.16.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - Authenticator Library For SMSOTP</name>
     <url>http://wso2.org</url>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,10 +19,10 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.smsotp</groupId>
         <artifactId>identity-outbound-auth-sms-otp</artifactId>
-        <version>2.0.16.3</version>
+        <version>2.0.16.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.smsotp.feature</artifactId>
-    <version>2.0.16.3</version>
+    <version>2.0.16.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - identity SMS OTP Feature</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.smsotp</groupId>
     <artifactId>identity-outbound-auth-sms-otp</artifactId>
-    <version>2.0.16.3</version>
+    <version>2.0.16.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - SMS OTP Pom</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
**Reason for the branch creation**

This 2.0.16.3.x branch is created to release the SMS OTP connector versions which are compatible with the IS-5.2.0. At the branch creation point, the existing version in the IS-5.2.0 was 2.0.16.3. Hence it was decided to create a branch from 2.0.16.3 tag. For the feature, (Account locking for SMS OTP) that is going to introduce for IS-5.2.0, it is required to have the framework version of 5.2.2. But in 2.0.16.x branch, the framework version was already upgraded to 5.7.0. Therefore it can't be downgraded to 5.2.2 since the SMS OTP connectors which were released from 2.0.16.x, were already used in other IS product versions as well. Hence, considering these reasons 2.0.16.3.x branch was created.