### PR TITLE
Change hashing algo and remove OTP from response

### DIFF
--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.smsotp.common.util;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -64,6 +65,11 @@ public class Utils {
         }
         log.debug(String.format("SMS OTP service configurations : %s.",
                 SMSOTPServiceDataHolder.getConfigs().toString()));
+    }
+
+    public static String getHash(String text) {
+
+        return DigestUtils.sha256Hex(text);
     }
 
     private static void sanitizeAndPopulateConfigs(Properties properties) throws SMSOTPServerException {
@@ -129,7 +135,7 @@ public class Utils {
 
         String transactionId = UUID.randomUUID().toString();
         if (log.isDebugEnabled()) {
-            log.debug(String.format("Transaction Id hash: %s.", transactionId.hashCode()));
+            log.debug(String.format("Transaction Id hash: %s.", Utils.getHash(transactionId)));
         }
         return transactionId;
     }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -67,6 +67,12 @@ public class Utils {
                 SMSOTPServiceDataHolder.getConfigs().toString()));
     }
 
+    /**
+     * This method returns the SHA-256 hash of a given string.
+     *
+     * @param text  plain text.
+     * @return      SHA-256 hash value of the given plain text.
+     */
     public static String getHash(String text) {
 
         return DigestUtils.sha256Hex(text);


### PR DESCRIPTION
## Purpose
Change hashing algorithm to SHA-256
Removed OTP response from the SMS OTP generation request when notifications are handled by the Identity Server.