### PR TITLE
Return requested mobile from context for SMSOTP if user doesn't have mobile

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -82,6 +82,7 @@ import static org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants.CHAR
 import static org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants.MASKING_VALUE_SEPARATOR;
 
 import static java.util.Base64.getEncoder;
+import static org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants.REQUESTED_USER_MOBILE;
 
 /**
  * Authenticator of SMS OTP
@@ -1434,7 +1435,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
      * @throws UserStoreException
      */
     public String getScreenAttribute(AuthenticationContext context, UserRealm userRealm, String username)
-            throws UserStoreException, AuthenticationFailedException {
+            throws UserStoreException {
 
         String screenUserAttributeParam;
         String screenUserAttributeValue = null;
@@ -1445,9 +1446,13 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         if (screenUserAttributeParam != null) {
             screenUserAttributeValue = userRealm.getUserStoreManager()
                     .getUserClaimValue(username, screenUserAttributeParam, null);
+
+            if (StringUtils.isBlank(screenUserAttributeValue)) {
+                screenUserAttributeValue = String.valueOf(context.getProperty(REQUESTED_USER_MOBILE));
+            }
         }
 
-        if (screenUserAttributeValue != null) {
+        if (StringUtils.isNotBlank(screenUserAttributeValue)) {
             if ((SMSOTPUtils.getNoOfDigits(context)) != null) {
                 noOfDigits = Integer.parseInt(SMSOTPUtils.getNoOfDigits(context));
             }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -84,6 +84,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.*;
+import static org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants.REQUESTED_USER_MOBILE;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ConfigurationFacade.class, SMSOTPUtils.class, FederatedAuthenticatorUtil.class, FrameworkUtils.class,
@@ -662,6 +663,29 @@ public class SMSOTPAuthenticatorTest {
         // with backward order
         when(SMSOTPUtils.getDigitsOrder(context)).thenReturn("backward");
         Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"******5231");
+    }
+
+    @Test
+    public void testGetScreenAttributeWhenMobileRequest() throws UserStoreException {
+        mockStatic(IdentityTenantUtil.class);
+        mockStatic(SMSOTPUtils.class);
+        when(SMSOTPUtils.getScreenUserAttribute(context)).thenReturn
+                ("http://wso2.org/claims/mobile");
+        when(context.getProperty(REQUESTED_USER_MOBILE)).thenReturn("0778899889");
+        when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
+        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userRealm.getUserStoreManager()
+                .getUserClaimValue("admin", "http://wso2.org/claims/mobile", null)).thenReturn(null);
+        when(SMSOTPUtils.getNoOfDigits(context)).thenReturn("4");
+
+        // with forward order
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"0778******");
+
+        // with backward order
+        when(SMSOTPUtils.getDigitsOrder(context)).thenReturn("backward");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"******9889");
     }
 
     @Test(expectedExceptions = {SMSOTPException.class})


### PR DESCRIPTION
Fixing issue [1]. When user doesn't have mobile number configured in user store, SMSOTP workflow requested the mobile number at the login but doesn't show the screen attribute (masked mobile number user entered) when _OTP code view_ is prompted.

Fix is to retrieve the `requested mobile` from the authentication context if the user doesn't have the mobile number configured.

[1] https://github.com/wso2/product-is/issues/13150