### PR TITLE
Encoding SMS OTP payload based on the content type

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -19,11 +19,13 @@
 
 package org.wso2.carbon.identity.authenticator.smsotp;
 
+import com.google.gson.Gson;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.owasp.encoder.Encode;
 import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
 import org.wso2.carbon.extension.identity.helper.IdentityHelperConstants;
 import org.wso2.carbon.extension.identity.helper.util.IdentityHelperUtil;
@@ -1042,37 +1044,41 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the connection and proceed with SMS API's rest call.
      *
-     * @param httpConnection  the connection
-     * @param context         the authenticationContext
-     * @param headerString    the header string
-     * @param payload         the payload
-     * @param httpResponse    the http response
-     * @param encodedMobileNo the encoded mobileNo
-     * @param smsMessage      the sms message
-     * @param otpToken        the token
-     * @param httpMethod      the http method
+     * @param httpConnection        the connection
+     * @param context               the authenticationContext
+     * @param headerString          the header string
+     * @param payload               the payload
+     * @param httpResponse          the http response
+     * @param receivedMobileNumber  the encoded mobileNo
+     * @param smsMessage            the sms message
+     * @param otpToken              the token
+     * @param httpMethod            the http method
      * @return true or false
      * @throws AuthenticationFailedException
      */
     private boolean getConnection(HttpURLConnection httpConnection, AuthenticationContext context, String headerString,
-                                  String payload, String httpResponse, String encodedMobileNo, String smsMessage,
+                                  String payload, String httpResponse, String receivedMobileNumber, String smsMessage,
                                   String otpToken, String httpMethod) throws AuthenticationFailedException {
 
         try {
             httpConnection.setDoInput(true);
             httpConnection.setDoOutput(true);
+            String encodedMobileNo = URLEncoder.encode(receivedMobileNumber, CHAR_SET_UTF_8);
+            String encodedSMSMessage;
             String[] headerArray;
+            HashMap<String, Object> headerElementProperties = new HashMap<>();
             if (StringUtils.isNotEmpty(headerString)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Processing HTTP headers since header string is available");
                 }
-                headerString = headerString.trim().replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg",
-                        smsMessage + otpToken);
+                headerString = headerString.trim().replaceAll("\\$ctx.num", receivedMobileNumber).replaceAll(
+                        "\\$ctx.msg", smsMessage + otpToken);
                 headerArray = headerString.split(",");
                 for (String header : headerArray) {
                     String[] headerElements = header.split(":");
                     if (headerElements.length > 1) {
                         httpConnection.setRequestProperty(headerElements[0], headerElements[1]);
+                        headerElementProperties.put(headerElements[0], headerElements[1]);
                     } else {
                         log.info("Either header name or value not found. Hence not adding header which contains " +
                                 headerElements[0]);
@@ -1095,9 +1101,20 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             } else if (SMSOTPConstants.POST_METHOD.equalsIgnoreCase(httpMethod)) {
                 httpConnection.setRequestMethod(SMSOTPConstants.POST_METHOD);
                 if (StringUtils.isNotEmpty(payload)) {
-                    payload = payload.replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg", smsMessage +
-                            otpToken);
-
+                    String contentType = ((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE)).trim();
+                    if (!SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)){
+                        encodedSMSMessage = smsMessage;
+                        if (StringUtils.isNotBlank(contentType) && SMSOTPConstants.POST_METHOD.equals(httpMethod) &&
+                                (SMSOTPConstants.JSON_CONTENT_TYPE).equals(contentType)) {
+                            encodedMobileNo = receivedMobileNumber;
+                        }
+                    }
+                    else{
+                        encodedMobileNo = getEncodedValue(contentType,receivedMobileNumber);
+                        encodedSMSMessage = getEncodedValue(contentType,smsMessage);
+                    }
+                    payload = payload.replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg",
+                            encodedSMSMessage + otpToken);
                     OutputStreamWriter writer = null;
                     try {
                         writer = new OutputStreamWriter(httpConnection.getOutputStream(), SMSOTPConstants.CHAR_SET_UTF_8);
@@ -1114,7 +1131,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             if (StringUtils.isNotEmpty(httpResponse)) {
                 if (httpResponse.trim().equals(String.valueOf(httpConnection.getResponseCode()))) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Code is successfully sent to the mobile and recieved expected response code : " +
+                        log.debug("Code is successfully sent to the mobile and received expected response code : " +
                                 httpResponse);
                     }
                     return true;
@@ -1233,35 +1250,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         HttpURLConnection httpConnection;
         boolean connection;
         String smsMessage = SMSOTPConstants.SMS_MESSAGE;
-        String[] headerArray;
         String receivedMobileNumber = URLEncoder.encode(mobile, CHAR_SET_UTF_8);
-        HashMap<String, Object> headerElementProperties = new HashMap<>();
-        if (StringUtils.isNotEmpty(headerString)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Processing HTTP headers since header string is available");
-            }
-            headerArray = headerString.split(",");
-            for (String header : headerArray) {
-                String[] headerElements = header.split(":");
-                if (headerElements.length > 1) {
-                    headerElementProperties.put(headerElements[0], headerElements[1]);
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Either header name or value not found. Hence not adding header which contains " +
-                                headerElements[0]);
-                    }
-                }
-            }
-            String contentType = (String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE);
-            if (StringUtils.isNotBlank(contentType) && SMSOTPConstants.POST_METHOD.equals(httpMethod) &&
-                    (SMSOTPConstants.JSON_CONTENT_TYPE).equals(contentType.trim())) {
-                receivedMobileNumber = mobile;
-            }
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("No configured headers found. Header string is empty");
-            }
-        }
         smsUrl = smsUrl.replaceAll("\\$ctx.num", receivedMobileNumber).replaceAll("\\$ctx.msg",
                 smsMessage.replaceAll("\\s", "+") + otpToken);
         URL smsProviderUrl = null;
@@ -1279,14 +1268,37 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         String subUrl = smsProviderUrl.getProtocol();
         if (subUrl.equals(SMSOTPConstants.HTTPS)) {
             httpConnection = (HttpsURLConnection) smsProviderUrl.openConnection();
-            connection = getConnection(httpConnection, context, headerString, payload, httpResponse,
-                    receivedMobileNumber, smsMessage, otpToken, httpMethod);
         } else {
             httpConnection = (HttpURLConnection) smsProviderUrl.openConnection();
-            connection = getConnection(httpConnection, context, headerString, payload, httpResponse,
-                    receivedMobileNumber, smsMessage, otpToken, httpMethod);
         }
+        connection = getConnection(httpConnection, context, headerString, payload, httpResponse, mobile,
+                smsMessage, otpToken, httpMethod);
         return connection;
+    }
+
+    /**
+     * Get the corresponding encoded value based on the provided content-type.
+     *
+     * @param contentType   The content type.
+     * @param value         String that needed to be encoded.
+     * @return The encoded value.
+     * @throws IOException
+     */
+    private String getEncodedValue(String contentType, String value) throws IOException{
+
+        String encodedValue;
+        switch (contentType){
+            case SMSOTPConstants.XML_CONTENT_TYPE:
+                encodedValue = Encode.forXml(value);
+                break;
+            case SMSOTPConstants.JSON_CONTENT_TYPE:
+                Gson gson = new Gson();
+                encodedValue = gson.toJson(value);
+                break;
+            default:
+                encodedValue = URLEncoder.encode(value, CHAR_SET_UTF_8);
+        }
+        return encodedValue;
     }
 
     /**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -67,12 +67,14 @@ public class SMSOTPConstants {
     public static final String USE_INTERNAL_ERROR_CODES = "UseInternalErrorCodes";
     public static final String SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+    public static final String ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP = "EnablePayloadEncodingForSMSOTP";
 
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";
 
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String JSON_CONTENT_TYPE = "application/json";
+    public static final String XML_CONTENT_TYPE = "text/xml;charset=UTF-8";
 
     public static final String SMSOTP_AUTHENTICATION_ENDPOINT_URL = "SMSOTPAuthenticationEndpointURL";
     public static final String SMSOTP_AUTHENTICATION_ERROR_PAGE_URL = "SMSOTPAuthenticationEndpointErrorPage";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -67,7 +67,7 @@ public class SMSOTPConstants {
     public static final String USE_INTERNAL_ERROR_CODES = "UseInternalErrorCodes";
     public static final String SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
-    public static final String ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP = "EnablePayloadEncodingForSMSOTP";
+    public static final String ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP = "enable_payload_encoding_for_sms_otp";
 
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
@@ -539,4 +539,16 @@ public class SMSOTPUtils {
         }
         return false;
     }
+
+    /**
+     * Checks whether the payload encoding for sms otp is enabled.
+     *
+     * @param context Authentication context.
+     * @return True if encoding is enabled.
+     */
+    public static boolean isPayloadEncodingForSMSOTPEnabled(AuthenticationContext context) {
+
+        return Boolean
+                .parseBoolean(getConfiguration(context, SMSOTPConstants.ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP));
+    }
 }


### PR DESCRIPTION
## Purpose
This PR will resolve the issue of URL encoding the payload of SMS OTP irrespective of the content type. With this fix, the payload will be encoded based on the content type. To provide backward compatibility the encoding based on content type will be enabled via a configuration. By default encoding based on the content type will be disabled and to enable encoding the following configuration need to be added to `deployment.toml`.

```
[authentication.authenticator.sms_otp.parameters]
enable_payload_encoding_for_sms_otp = false
```

## Approach
here payload encoding will be performed as below.

- `text/xml;charset=UTF-8` content type will be XML encoded using `org.owasp.encoder` library.
- `application/json` content type will be parsed using `com.google.gson` library.
- all the responses in other content types will be URL encoded. 

Resolves : [wso2/product-is#13226](https://github.com/wso2/product-is/issues/13226)