### PR TITLE
Invalidate sms-otp for multiple failed validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ properties.tokenRenewalInterval=60
 # Throttle OTP generation requests from the same user Id.
 # Set '0' for no throttling.
 properties.resendThrottleInterval=30
+# Set the maximum validation attempts allowed until the generated sms-otp expires.
+properties.maxValidationAttemptsAllowed=5
 ```
 4. If notifications are managed by the Identity Server, configure the **SMS template** by appending below at the end of
    the `<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file.

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -144,9 +144,10 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             return new ValidationResponseDTO(userId, false, error);
         }
         SessionDTO sessionDTO;
+        int validateAttempt;
         try {
             sessionDTO = new ObjectMapper().readValue(jsonString, SessionDTO.class);
-            int validateAttempt = sessionDTO.getValidationAttempts();
+            validateAttempt = sessionDTO.getValidationAttempts();
             FailureReasonDTO error;
             if (validateAttempt >= SMSOTPServiceDataHolder.getConfigs().getMaxValidationAttemptsAllowed()) {
                 SessionDataStore.getInstance().clearSessionData(sessionId, Constants.SESSION_TYPE_OTP);
@@ -154,8 +155,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
                         ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_BLOCKED, userId)
                         : null;
                 return new ValidationResponseDTO(userId, false, error);
-            }
-            else {
+            } else {
                 validateAttempt++;
                 sessionDTO.setValidationAttempts(validateAttempt);
                 persistOTPSession(sessionDTO, sessionId);
@@ -164,7 +164,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_JSON_SESSION_MAPPER_ERROR, null, e);
         }
 
-        ValidationResponseDTO responseDTO = isValid(sessionDTO, smsOTP, userId, transactionId, showFailureReason);
+        ValidationResponseDTO responseDTO = isValid(sessionDTO, smsOTP, userId, transactionId, validateAttempt, showFailureReason);
         if (!responseDTO.isValid()) {
             return responseDTO;
         }
@@ -174,7 +174,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
     }
 
     private ValidationResponseDTO isValid(SessionDTO sessionDTO, String smsOTP, String userId,
-                                          String transactionId, boolean showFailureReason) {
+                                          String transactionId, int validateAttempt, boolean showFailureReason) {
 
         FailureReasonDTO error;
         // Check if the provided OTP is correct.
@@ -182,9 +182,11 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Invalid OTP provided for the user : %s.", userId));
             }
+            int remainingFailedAttempts =
+                    SMSOTPServiceDataHolder.getConfigs().getMaxValidationAttemptsAllowed() - validateAttempt;
             error = showFailureReason
-                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, userId)
-                    : null;
+                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, userId,
+                    remainingFailedAttempts) : null;
             return new ValidationResponseDTO(userId, false, error);
         }
         // Check for expired OTPs.

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -68,7 +68,7 @@ public class Constants {
         CLIENT_MANDATORY_VALIDATION_PARAMETERS_EMPTY("SMS-60007", "Mandatory parameters not found.",
                 "Mandatory parameters not found : %s."),
         CLIENT_OTP_VALIDATION_FAILED("SMS-60008", "Provided OTP is invalid.",
-                "Provided OTP is invalid. User id : %s. Remaining validation attempts : %s"),
+                "Provided OTP is invalid. User id : %s."),
         CLIENT_NO_OTP_FOR_USER("SMS-60009", "No OTP fround for the user.",
                 "No OTP found for the user Id : %s."),
         CLIENT_SLOW_DOWN_RESEND("SMS-60010", "Slow down.",

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -68,13 +68,13 @@ public class Constants {
         CLIENT_MANDATORY_VALIDATION_PARAMETERS_EMPTY("SMS-60007", "Mandatory parameters not found.",
                 "Mandatory parameters not found : %s."),
         CLIENT_OTP_VALIDATION_FAILED("SMS-60008", "Provided OTP is invalid.",
-                "Provided OTP is invalid. User id : %s."),
+                "Provided OTP is invalid. User id : %s. Remaining validation attempts : %s"),
         CLIENT_NO_OTP_FOR_USER("SMS-60009", "No OTP fround for the user.",
                 "No OTP found for the user Id : %s."),
         CLIENT_SLOW_DOWN_RESEND("SMS-60010", "Slow down.",
                 "Please wait %s seconds before retrying."),
-        CLIENT_OTP_VALIDATION_BLOCKED("SMS-60011", "Maximum no of failed validation attempted exceeded.",
-                "Maximum no of failed validation attempted exceeded. User id : %s."),
+        CLIENT_OTP_VALIDATION_BLOCKED("SMS-60011", "Maximum allowed failed validation attempts exceeded.",
+                "Maximum allowed failed validation attempts exceeded for user id : %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("SMS-65001", "User store manager error.",

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
     public static final int DEFAULT_OTP_LENGTH = 6;
     public static final int DEFAULT_SMS_OTP_VALIDITY_PERIOD = 60000;
     public static final int DEFAULT_RESEND_THROTTLE_INTERVAL = 30000;
+    public static final int DEFAULT_MAX_VALIDATION_ATTEMPTS_ALLOWED = 5;
     public static final String SMS_OTP_NOTIFICATION_TEMPLATE = "sendOTP";
 
     public static final String SMS_OTP_IDENTITY_EVENT_MODULE_NAME = "smsOtp";
@@ -46,6 +47,7 @@ public class Constants {
     public static final String SMS_OTP_TRIGGER_NOTIFICATION = "smsOtp.triggerNotification";
     public static final String SMS_OTP_TOKEN_RENEWAL_INTERVAL = "smsOtp.tokenRenewalInterval";
     public static final String SMS_OTP_RESEND_THROTTLE_INTERVAL = "smsOtp.resendThrottleInterval";
+    public static final String SMS_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED = "smsOtp.maxValidationAttemptsAllowed";
     public static final String SMS_OTP_SHOW_FAILURE_REASON = "smsOtp.showValidationFailureReason";
 
     /**
@@ -71,6 +73,8 @@ public class Constants {
                 "No OTP found for the user Id : %s."),
         CLIENT_SLOW_DOWN_RESEND("SMS-60010", "Slow down.",
                 "Please wait %s seconds before retrying."),
+        CLIENT_OTP_VALIDATION_BLOCKED("SMS-60011", "Maximum no of failed validation attempted exceeded.",
+                "Maximum no of failed validation attempted exceeded. User id : %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("SMS-65001", "User store manager error.",

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
@@ -136,10 +136,12 @@ public class ConfigsDTO {
     }
 
     public int getMaxValidationAttemptsAllowed() {
+
         return maxValidationAttemptsAllowed;
     }
 
     public void setMaxValidationAttemptsAllowed(int maxValidationAttemptsAllowed) {
+
         this.maxValidationAttemptsAllowed = maxValidationAttemptsAllowed;
     }
 

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
@@ -33,6 +33,7 @@ public class ConfigsDTO {
     private int otpValidityPeriod;
     private int otpRenewalInterval;
     private int resendThrottleInterval;
+    private int maxValidationAttemptsAllowed;
 
     public boolean isEnabled() {
 
@@ -134,6 +135,14 @@ public class ConfigsDTO {
         this.resendThrottleInterval = resendThrottleInterval;
     }
 
+    public int getMaxValidationAttemptsAllowed() {
+        return maxValidationAttemptsAllowed;
+    }
+
+    public void setMaxValidationAttemptsAllowed(int maxValidationAttemptsAllowed) {
+        this.maxValidationAttemptsAllowed = maxValidationAttemptsAllowed;
+    }
+
     @Override
     public String toString() {
 
@@ -148,6 +157,7 @@ public class ConfigsDTO {
                 .append(",\n\totpValidityPeriod = ").append(otpValidityPeriod)
                 .append(",\n\totpRenewalInterval = ").append(otpRenewalInterval)
                 .append(",\n\tresendThrottleInterval = ").append(resendThrottleInterval)
+                .append(",\n\tmaxValidationAttemptsAllowed = ").append(maxValidationAttemptsAllowed)
                 .append("\n}");
         return sb.toString();
     }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/FailureReasonDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/FailureReasonDTO.java
@@ -46,6 +46,21 @@ public class FailureReasonDTO {
                 : error.getDescription();
     }
 
+    /**
+     * This method composes the error message for failed sms-otp validation attempts.
+     *
+     * @param error                     Error message.
+     * @param data                      Data passed for the string argument in error message.
+     * @param remainingFailedAttempts   No of remaining validation attempts.
+     */
+    public FailureReasonDTO(Constants.ErrorMessage error, String data, int remainingFailedAttempts) {
+
+        this.code = error.getCode();
+        this.message = error.getMessage();
+        description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data, remainingFailedAttempts)
+                : error.getDescription();
+    }
+
     public String getCode() {
 
         return code;

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/FailureReasonDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/FailureReasonDTO.java
@@ -30,12 +30,22 @@ public class FailureReasonDTO {
     String code;
     String message;
     String description;
+    int remainingAttempts;
 
     public FailureReasonDTO(String code, String message, String description) {
 
         this.code = code;
         this.message = message;
         this.description = description;
+        this.remainingAttempts = 0;
+    }
+
+    public FailureReasonDTO(String code, String message, String description, int remainingAttempts) {
+
+        this.code = code;
+        this.message = message;
+        this.description = description;
+        this.remainingAttempts = remainingAttempts;
     }
 
     public FailureReasonDTO(Constants.ErrorMessage error, String data) {
@@ -44,6 +54,7 @@ public class FailureReasonDTO {
         this.message = error.getMessage();
         description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data)
                 : error.getDescription();
+        this.remainingAttempts = 0;
     }
 
     /**
@@ -57,8 +68,9 @@ public class FailureReasonDTO {
 
         this.code = error.getCode();
         this.message = error.getMessage();
-        description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data, remainingFailedAttempts)
+        description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data)
                 : error.getDescription();
+        this.remainingAttempts = remainingFailedAttempts;
     }
 
     public String getCode() {
@@ -89,5 +101,15 @@ public class FailureReasonDTO {
     public void setDescription(String description) {
 
         this.description = description;
+    }
+
+    public int getRemainingAttempts() {
+
+        return remainingAttempts;
+    }
+
+    public void setRemainingAttempts(int remainingAttempts) {
+
+        this.remainingAttempts = remainingAttempts;
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/SessionDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/SessionDTO.java
@@ -34,6 +34,7 @@ public class SessionDTO implements Serializable {
     private String transactionId;
     private String fullQualifiedUserName;
     private String userId;
+    private int validationAttempts;
 
     public String getOtp() {
 
@@ -95,6 +96,16 @@ public class SessionDTO implements Serializable {
         this.userId = userId;
     }
 
+    public int getValidationAttempts() {
+
+        return validationAttempts;
+    }
+
+    public void setValidationAttempts(int validationAttempts) {
+
+        this.validationAttempts = validationAttempts;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -109,13 +120,15 @@ public class SessionDTO implements Serializable {
                 getExpiryTime() == that.getExpiryTime() &&
                 getOtp().equals(that.getOtp()) &&
                 getFullQualifiedUserName().equals(that.getFullQualifiedUserName()) &&
-                getUserId().equals(that.getUserId());
+                getUserId().equals(that.getUserId()) &&
+                getValidationAttempts() == that.getValidationAttempts();
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(getOtp(), getGeneratedTime(), getExpiryTime(), getFullQualifiedUserName(), getUserId());
+        return Objects.hash(getOtp(), getGeneratedTime(), getExpiryTime(), getFullQualifiedUserName(), getUserId(),
+                getValidationAttempts());
     }
 
     @Override
@@ -128,6 +141,7 @@ public class SessionDTO implements Serializable {
                 .append(",\n\ttransactionId = ").append(transactionId)
                 .append(",\n\tfullQualifiedUserName = ").append(fullQualifiedUserName)
                 .append(",\n\tuserId = ").append(userId)
+                .append(",\n\tvalidationAttempts = ").append(validationAttempts)
                 .append("\n}");
         return sb.toString();
     }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -128,6 +128,13 @@ public class Utils {
                 Integer.parseInt(otpResendThrottleIntervalValue) * 1000 : Constants.DEFAULT_RESEND_THROTTLE_INTERVAL;
         configs.setResendThrottleInterval(resendThrottleInterval);
 
+        String otpmaxValidationAttemptsAllowedValue = StringUtils.trim(
+                properties.getProperty(Constants.SMS_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED));
+        int maxValidationAttemptsAllowed = StringUtils.isNumeric(otpmaxValidationAttemptsAllowedValue) ?
+                Integer.parseInt(otpmaxValidationAttemptsAllowedValue) :
+                Constants.DEFAULT_MAX_VALIDATION_ATTEMPTS_ALLOWED;
+        configs.setMaxValidationAttemptsAllowed(maxValidationAttemptsAllowed);
+
         // Should we send the same OTP upon the next generation request. Defaults to 'false'.
         boolean resendSameOtp = (otpRenewalInterval > 0) && (otpRenewalInterval < otpValidityPeriod);
         configs.setResendSameOtp(resendSameOtp);

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -128,10 +128,11 @@ public class Utils {
                 Integer.parseInt(otpResendThrottleIntervalValue) * 1000 : Constants.DEFAULT_RESEND_THROTTLE_INTERVAL;
         configs.setResendThrottleInterval(resendThrottleInterval);
 
-        String otpmaxValidationAttemptsAllowedValue = StringUtils.trim(
+        // Maximum allowed validation attempts defaults to 5 if its not specified as a property in deployment.toml file.
+        String otpMaxValidationAttemptsAllowedValue = StringUtils.trim(
                 properties.getProperty(Constants.SMS_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED));
-        int maxValidationAttemptsAllowed = StringUtils.isNumeric(otpmaxValidationAttemptsAllowedValue) ?
-                Integer.parseInt(otpmaxValidationAttemptsAllowedValue) :
+        int maxValidationAttemptsAllowed = StringUtils.isNumeric(otpMaxValidationAttemptsAllowedValue) ?
+                Integer.parseInt(otpMaxValidationAttemptsAllowedValue) :
                 Constants.DEFAULT_MAX_VALIDATION_ATTEMPTS_ALLOWED;
         configs.setMaxValidationAttemptsAllowed(maxValidationAttemptsAllowed);
 
@@ -172,6 +173,21 @@ public class Utils {
             description = String.format(error.getDescription(), data);
         } else {
             description = error.getDescription();
+        }
+        return new SMSOTPClientException(error.getCode(), error.getMessage(), description, e);
+    }
+
+    public static SMSOTPClientException handleClientException(Constants.ErrorMessage error, String data,
+                                                              int remainingFailedAttempts, Throwable e) {
+
+        String description;
+        if (StringUtils.isNotBlank(data)) {
+            description = String.format(error.getDescription(), data, remainingFailedAttempts);
+        } else {
+            description = error.getDescription();
+        }
+        if (e == null) {
+            return new SMSOTPClientException(error.getCode(), error.getMessage(), description);
         }
         return new SMSOTPClientException(error.getCode(), error.getMessage(), description, e);
     }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -177,21 +177,6 @@ public class Utils {
         return new SMSOTPClientException(error.getCode(), error.getMessage(), description, e);
     }
 
-    public static SMSOTPClientException handleClientException(Constants.ErrorMessage error, String data,
-                                                              int remainingFailedAttempts, Throwable e) {
-
-        String description;
-        if (StringUtils.isNotBlank(data)) {
-            description = String.format(error.getDescription(), data, remainingFailedAttempts);
-        } else {
-            description = error.getDescription();
-        }
-        if (e == null) {
-            return new SMSOTPClientException(error.getCode(), error.getMessage(), description);
-        }
-        return new SMSOTPClientException(error.getCode(), error.getMessage(), description, e);
-    }
-
     public static SMSOTPServerException handleServerException(Constants.ErrorMessage error, String data,
                                                               Throwable e) {
 

--- a/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/UtilsTest.java
+++ b/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/UtilsTest.java
@@ -57,26 +57,32 @@ public class UtilsTest {
     public void testHandleClientException() {
 
         String data = "sample data";
+        int remainingFailedAttempts = 3;
+        Exception e = null;
         SMSOTPClientException exception =
-                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data);
+                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data,
+                        remainingFailedAttempts, e);
         Assert.assertEquals(exception.getErrorCode(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getCode());
         Assert.assertEquals(exception.getMessage(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getMessage());
-        Assert.assertEquals(exception.getDescription(),
-                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data));
+        Assert.assertEquals(exception.getDescription(), String.format(
+                Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data, remainingFailedAttempts));
     }
 
     @Test
     public void testHandleClientExceptionWithThrowable() {
 
         String data = "sample data";
+        int remainingFailedAttempts = 3;
         Exception e = new Exception();
         SMSOTPClientException exception =
-                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data, e);
+                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data,
+                        remainingFailedAttempts, e);
         Assert.assertEquals(exception.getErrorCode(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getCode());
         Assert.assertEquals(exception.getMessage(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getMessage());
         Assert.assertEquals(exception.getCause(), e);
         Assert.assertEquals(exception.getDescription(),
-                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data));
+                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data,
+                        remainingFailedAttempts));
     }
 
     @Test

--- a/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/UtilsTest.java
+++ b/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/UtilsTest.java
@@ -57,32 +57,26 @@ public class UtilsTest {
     public void testHandleClientException() {
 
         String data = "sample data";
-        int remainingFailedAttempts = 3;
-        Exception e = null;
         SMSOTPClientException exception =
-                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data,
-                        remainingFailedAttempts, e);
+                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data);
         Assert.assertEquals(exception.getErrorCode(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getCode());
         Assert.assertEquals(exception.getMessage(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getMessage());
-        Assert.assertEquals(exception.getDescription(), String.format(
-                Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data, remainingFailedAttempts));
+        Assert.assertEquals(exception.getDescription(),
+                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data));
     }
 
     @Test
     public void testHandleClientExceptionWithThrowable() {
 
         String data = "sample data";
-        int remainingFailedAttempts = 3;
         Exception e = new Exception();
         SMSOTPClientException exception =
-                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data,
-                        remainingFailedAttempts, e);
+                Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, data, e);
         Assert.assertEquals(exception.getErrorCode(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getCode());
         Assert.assertEquals(exception.getMessage(), Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getMessage());
         Assert.assertEquals(exception.getCause(), e);
         Assert.assertEquals(exception.getDescription(),
-                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data,
-                        remainingFailedAttempts));
+                String.format(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED.getDescription(), data));
     }
 
     @Test


### PR DESCRIPTION
## Purpose
 SMS OTP Service does not invalidate issued OTP values in multiple failed validation attempts.

## Approach
 Store the no. of failed validation attempts as a new attribute in the session object and insert a new entry to the session store(IDN_AUTH_SESSION_STORE table) with the updated session object each time a validation request is sent until the maximum allowed validation attempts are passed. The maximum allowed validation attempts count is made configurable via deployment.toml file as shown in the example below.

```
[[event_handler]]
name= "smsOtp"
properties.enabled=true
properties.maxValidationAttemptsAllowed=4
```
Resolves git issue: https://github.com/wso2/product-is/issues/13291
