### PR TITLE
Payload encoding in sms otp public

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -134,7 +134,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 // if the request comes with authentication is basic, complete the flow.
                 return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
             }
-        }  else if (Boolean.parseBoolean(request.getParameter(SMSOTPConstants.RESEND))) {
+        } else if (Boolean.parseBoolean(request.getParameter(SMSOTPConstants.RESEND))) {
             AuthenticatorFlowStatus authenticatorFlowStatus = super.process(request, response, context);
             publishPostSMSOTPGeneratedEvent(request, context);
             return authenticatorFlowStatus;
@@ -210,11 +210,11 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the mobile number from user's profile to send an otp.
      *
-     * @param request      the HttpServletRequest
-     * @param response     the HttpServletResponse
-     * @param context      the AuthenticationContext
-     * @param username     the Username
-     * @param queryParams  the queryParams
+     * @param request     the HttpServletRequest
+     * @param response    the HttpServletResponse
+     * @param context     the AuthenticationContext
+     * @param username    the Username
+     * @param queryParams the queryParams
      * @return the mobile number
      * @throws AuthenticationFailedException
      * @throws SMSOTPException
@@ -519,8 +519,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                         response.sendRedirect(FrameworkUtils
                                 .appendQueryParamsStringToUrl(url, SMSOTPConstants.MOBILE_NUMBER_REGEX_PATTERN_QUERY +
                                         getEncoder().encodeToString(context.getAuthenticatorProperties()
-                                                        .get(SMSOTPConstants.MOBILE_NUMBER_REGEX)
-                                                        .getBytes()) +
+                                                .get(SMSOTPConstants.MOBILE_NUMBER_REGEX)
+                                                .getBytes()) +
                                         SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE_QUERY +
                                         getEncoder().encodeToString(mobileNumberPatternViolationError.getBytes())));
                     } else {
@@ -774,7 +774,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                         String failureReason = String.valueOf(
                                 context.getProperty(SMSOTPConstants.PROFILE_UPDATE_FAILURE_REASON));
                         String urlEncodedFailureReason = URLEncoder.encode(failureReason, CHAR_SET_UTF_8);
-                        String failureQueryParam = SMSOTPConstants.ERROR_MESSAGE_DETAILS +  urlEncodedFailureReason;
+                        String failureQueryParam = SMSOTPConstants.ERROR_MESSAGE_DETAILS + urlEncodedFailureReason;
                         url = FrameworkUtils.appendQueryParamsStringToUrl(url, failureQueryParam);
                     }
                 }
@@ -1173,15 +1173,15 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the connection and proceed with SMS API's rest call.
      *
-     * @param httpConnection        The connection.
-     * @param context               The authenticationContext.
-     * @param headerString          The header string.
-     * @param payload               The payload.
-     * @param httpResponse          The http response.
-     * @param receivedMobileNumber  The encoded mobileNo.
-     * @param smsMessage            The sms message.
-     * @param otpToken              The token.
-     * @param httpMethod            The http method.
+     * @param httpConnection       The connection.
+     * @param context              The authenticationContext.
+     * @param headerString         The header string.
+     * @param payload              The payload.
+     * @param httpResponse         The http response.
+     * @param receivedMobileNumber The encoded mobileNo.
+     * @param smsMessage           The sms message.
+     * @param otpToken             The token.
+     * @param httpMethod           The http method.
      * @return true or false
      * @throws AuthenticationFailedException
      */
@@ -1231,16 +1231,18 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 httpConnection.setRequestMethod(SMSOTPConstants.POST_METHOD);
                 if (StringUtils.isNotEmpty(payload)) {
                     String contentType = ((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE)).trim();
-                    if (!SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)){
+//                  If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
+//                  payload will be URL encoded for all the content-types except for application/json content type
+//                  preserving the previous implementation to support backward compatibility.
+                    if (SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)) {
+                        encodedMobileNo = getEncodedValue(contentType, receivedMobileNumber);
+                        encodedSMSMessage = getEncodedValue(contentType, smsMessage);
+                    } else {
                         encodedSMSMessage = smsMessage;
                         if (StringUtils.isNotBlank(contentType) && SMSOTPConstants.POST_METHOD.equals(httpMethod) &&
                                 (SMSOTPConstants.JSON_CONTENT_TYPE).equals(contentType)) {
                             encodedMobileNo = receivedMobileNumber;
                         }
-                    }
-                    else{
-                        encodedMobileNo = getEncodedValue(contentType,receivedMobileNumber);
-                        encodedSMSMessage = getEncodedValue(contentType,smsMessage);
                     }
                     payload = payload.replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg",
                             encodedSMSMessage + otpToken);
@@ -1413,15 +1415,15 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the corresponding encoded value based on the provided content-type.
      *
-     * @param contentType   The content type.
-     * @param value         String that needed to be encoded.
-     * @return The encoded value.
+     * @param contentType The content type in the request header.
+     * @param value       String value that needed to be encoded.
+     * @return The encoded value based on the content-type.
      * @throws IOException
      */
-    private String getEncodedValue(String contentType, String value) throws IOException{
+    private String getEncodedValue(String contentType, String value) throws IOException {
 
         String encodedValue;
-        switch (contentType){
+        switch (contentType) {
             case SMSOTPConstants.XML_CONTENT_TYPE:
                 encodedValue = Encode.forXml(value);
                 break;
@@ -1685,7 +1687,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             UserRealm userRealm = getUserRealm(authenticatedUser);
             UserStoreManager userStoreManager = userRealm.getUserStoreManager();
             claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
-                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+                            authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
                             SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM,
                             SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
                     UserCoreConstants.DEFAULT_PROFILE);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -210,11 +210,11 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
     /**
      * Get the mobile number from user's profile to send an otp.
      *
-     * @param request     the HttpServletRequest
-     * @param response    the HttpServletResponse
-     * @param context     the AuthenticationContext
-     * @param username    the Username
-     * @param queryParams the queryParams
+     * @param request     The HttpServletRequest.
+     * @param response    The HttpServletResponse.
+     * @param context     The AuthenticationContext.
+     * @param username    The Username.
+     * @param queryParams The queryParams.
      * @return the mobile number
      * @throws AuthenticationFailedException
      * @throws SMSOTPException
@@ -1235,8 +1235,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                     payload will be URL encoded for all the content-types except for application/json content type
                     preserving the previous implementation to support backward compatibility.*/
                     if (SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)) {
-//                      here only the mobile number and SMS message will be encoded, assuming the rest of the content is
-//                      in correct format.
+/*                      here only the mobile number and SMS message will be encoded, assuming the rest of the content is
+                        in correct format.*/
                         encodedMobileNo = getEncodedValue(contentType, receivedMobileNumber);
                         encodedSMSMessage = getEncodedValue(contentType, smsMessage);
                     } else {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1235,6 +1235,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
 //                  payload will be URL encoded for all the content-types except for application/json content type
 //                  preserving the previous implementation to support backward compatibility.
                     if (SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)) {
+//                      here only the mobile number and SMS message will be encoded, assuming the rest of the content is
+//                      in correct format.
                         encodedMobileNo = getEncodedValue(contentType, receivedMobileNumber);
                         encodedSMSMessage = getEncodedValue(contentType, smsMessage);
                     } else {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1231,12 +1231,16 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 httpConnection.setRequestMethod(SMSOTPConstants.POST_METHOD);
                 if (StringUtils.isNotEmpty(payload)) {
                     String contentType = ((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE)).trim();
-/*                  If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
+                    /*
+                    If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
                     payload will be URL encoded for all the content-types except for application/json content type
-                    preserving the previous implementation to support backward compatibility.*/
+                    preserving the previous implementation to support backward compatibility.
+                    */
                     if (SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)) {
-/*                      here only the mobile number and SMS message will be encoded, assuming the rest of the content is
-                        in correct format.*/
+                        /*
+                        here only the mobile number and SMS message will be encoded, assuming the rest of the content is
+                        in correct format.
+                        */
                         encodedMobileNo = getEncodedValue(contentType, receivedMobileNumber);
                         encodedSMSMessage = getEncodedValue(contentType, smsMessage);
                     } else {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1231,9 +1231,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 httpConnection.setRequestMethod(SMSOTPConstants.POST_METHOD);
                 if (StringUtils.isNotEmpty(payload)) {
                     String contentType = ((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE)).trim();
-//                  If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
-//                  payload will be URL encoded for all the content-types except for application/json content type
-//                  preserving the previous implementation to support backward compatibility.
+/*                  If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
+                    payload will be URL encoded for all the content-types except for application/json content type
+                    preserving the previous implementation to support backward compatibility.*/
                     if (SMSOTPUtils.isPayloadEncodingForSMSOTPEnabled(context)) {
 //                      here only the mobile number and SMS message will be encoded, assuming the rest of the content is
 //                      in correct format.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -70,12 +70,14 @@ public class SMSOTPConstants {
     public static final String USE_INTERNAL_ERROR_CODES = "UseInternalErrorCodes";
     public static final String SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+    public static final String ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP = "enable_payload_encoding_for_sms_otp";
 
     public static final String GET_METHOD = "GET";
     public static final String POST_METHOD = "POST";
 
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String JSON_CONTENT_TYPE = "application/json";
+    public static final String XML_CONTENT_TYPE = "text/xml;charset=UTF-8";
 
     public static final String SMSOTP_AUTHENTICATION_ENDPOINT_URL = "SMSOTPAuthenticationEndpointURL";
     public static final String SMSOTP_AUTHENTICATION_ERROR_PAGE_URL = "SMSOTPAuthenticationEndpointErrorPage";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
@@ -540,4 +540,17 @@ public class SMSOTPUtils {
         }
         return false;
     }
+
+
+    /**
+     * Checks whether the payload encoding for sms otp is enabled.
+     *
+     * @param context Authentication context.
+     * @return True if encoding is enabled.
+     */
+    public static boolean isPayloadEncodingForSMSOTPEnabled(AuthenticationContext context) {
+
+        return Boolean
+                .parseBoolean(getConfiguration(context, SMSOTPConstants.ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP));
+    }
 }


### PR DESCRIPTION
## Purpose

his PR will resolve the issue of URL encoding of the payload of SMS OTP irrespective of the content type.

With this fix, the payload will be encoded based on the content type. To provide backward compatibility the encoding based on content type will be enabled via a configuration. By default encoding based on the content-type will be enabled, which means content-type based encoding will be performed. To disable encoding the following configuration need to be added to `deployment.toml`.

```
[authentication.authenticator.sms_otp.parameters]
enable_payload_encoding_for_sms_otp = true
```

## Approach

here payload encoding will be performed as below.

- `text/xml;charset=UTF-8` content type will be XML encoded using `org.owasp.encoder` library.
- `application/json` content type will be parsed using `com.google.gson` library.
- all the responses in other content types will be URL encoded.

Resolves : [wso2/product-is#13226](https://github.com/wso2/product-is/issues/13226)
Related PRs : [wso2/carbon-identity-framework#3972](https://github.com/wso2/carbon-identity-framework/pull/3972)