### PR TITLE
[5.11.0][U2] Use StringUtils trimToEmpty for trimming to avoid NPE

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1101,7 +1101,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             } else if (SMSOTPConstants.POST_METHOD.equalsIgnoreCase(httpMethod)) {
                 httpConnection.setRequestMethod(SMSOTPConstants.POST_METHOD);
                 if (StringUtils.isNotEmpty(payload)) {
-                    String contentType = ((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE)).trim();
+                    String contentType =
+                            StringUtils.trimToEmpty((String) headerElementProperties.get(SMSOTPConstants.CONTENT_TYPE));
                     /*
                     If the enable_payload_encoding_for_sms_otp configuration is disabled, mobile number in the
                     payload will be URL encoded for all the content-types except for application/json content type


### PR DESCRIPTION
## Purpose
> Use StringUtils trimToEmpty for trimming to avoid NPE

Resolves [product-is #13552](https://github.com/wso2/product-is/issues/13552)