### PR TITLE
[3.0.x] Add SMS notification channel to event publisher

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -93,6 +93,10 @@
             <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
             <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -122,6 +126,8 @@
                             org.osgi.framework,
                             org.osgi.service.component; version="${osgi.service.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*,
+                            org.wso2.carbon.identity.governance.service.notification;
+                            version="${identity.governance.imp.pkg.version.range}",
                             javax.servlet,
                             javax.servlet.http,
                             org.wso2.carbon.extension.identity.helper.*;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -1374,6 +1375,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         properties.put(IdentityEventConstants.EventProperty.USER_NAME, userName);
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomainName);
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
+        properties.put(IdentityEventConstants.EventProperty.NOTIFICATION_CHANNEL,
+                NotificationChannels.SMS_CHANNEL.getChannelType());
 
         properties.put(SMSOTPConstants.ATTRIBUTE_SMS_SENT_TO, mobileNumber);
         properties.put(SMSOTPConstants.OTP_TOKEN, otpCode);

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,25 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.governance</artifactId>
+                <version>${identity.governance.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -400,6 +419,7 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.16.0</carbon.identity.version>
+        <identity.governance.version>1.4.1</identity.governance.version>
         <carbon.identity.version.range>[5.16.0,5.18.0)</carbon.identity.version.range>
         <commons-logging.version>4.4.11</commons-logging.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
@@ -432,5 +452,6 @@
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <osgi.service.import.version.range>[1.2.0,2.0.0)</osgi.service.import.version.range>
+        <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
A product issue was identified upon trying out the SMS publisher flow with the SMS OTP template added to `<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file. The SMSOTP template is not picked from the above mentioned file and results in the following error. 
```
Error occurred while calling triggerNotification, detail : org.wso2.carbon.identity.governance.exceptions.notiification.NotificationTemplateManagerServerException: Cannot find 'SMSOTP' template in the default 'en_US' locale for 'carbon.super' tenant
```
This behaviour occurs as the SMS channel is not added to the event in the SMS Authenticator. Hence the email template is selected [1] from the handler

[1] https://github.com/wso2-support/identity-event-handler-notification/blob/support-1.3.13.x-full/components/event-handler-notification/org.wso2.carbon.identity.event.handler.notification/src/main/java/org/wso2/carbon/identity/event/handler/notification/DefaultNotificationHandler.java#L149 

Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/126