### PR TITLE
[U2][5.11.0] Improvement for error logs in SMSOTPAuthenticator.getConnection method

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1143,6 +1143,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                                 httpResponse);
                     }
                     return true;
+                } else {
+                    log.error("Error while sending SMS: error code is " + httpConnection.getResponseCode()
+                            + " and error message is " + httpConnection.getResponseMessage());
                 }
             } else {
                 if (httpConnection.getResponseCode() == 200 || httpConnection.getResponseCode() == 201
@@ -1192,8 +1195,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             screenValue = getMaskedValue(context, encodedMobileNo, noOfDigits);
         }
         String content = contentRaw.replace(encodedMobileNo, screenValue);
-        URLDecoder decoder = new URLDecoder();
-        String decodedMobileNo = decoder.decode(encodedMobileNo);
+        String decodedMobileNo = URLDecoder.decode(encodedMobileNo);
         content = content.replace(decodedMobileNo, screenValue);
         content = maskConfiguredValues(context, content);
         context.setProperty(SMSOTPConstants.ERROR_INFO, content);


### PR DESCRIPTION
## Purpose
> Add additional error logs for `org.wso2.carbon.identity.authenticator.smsotp.SMSOTPAuthenticator.getConnection() ` function.
Issue :  https://github.com/wso2/product-is/issues/14846

## Goals
> Add debug log for unexpected http response code received.

## Approach
> If an unexpected http response code is received and debug is enabled, an error log is added with the received http response code. 