### PR TITLE
Fix SMS OTP account locked error not shown when configured with multi options

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -194,8 +194,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 }
                 processSMSOTPMandatoryCase(context, request, response, queryParams, username, isUserExists);
             } else if (isUserExists && !SMSOTPUtils.isSMSOTPDisableForLocalUser(username, context)) {
-                if (context.isRetrying() && !Boolean.parseBoolean(request.getParameter(SMSOTPConstants.RESEND))
-                        && !isMobileNumberUpdateFailed(context)) {
+                if ((context.isRetrying() && !Boolean.parseBoolean(request.getParameter(SMSOTPConstants.RESEND))
+                        && !isMobileNumberUpdateFailed(context)) || (SMSOTPUtils.isLocalUser(context) &&
+                        SMSOTPUtils.isAccountLocked(authenticatedUser))) {
                     if (log.isDebugEnabled()) {
                         log.debug("Triggering SMS OTP retry flow");
                     }
@@ -999,8 +1000,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 context.setProperty(SMSOTPConstants.CODE_MISMATCH, true);
             }
         } catch (UserStoreException e) {
-            throw new AuthenticationFailedException("Cannot find the user claim for OTP list for user : " +
-                    authenticatedUser, e);
+            log.error("Cannot find the user claim for OTP list for user : " + authenticatedUser, e);
         }
         return isMatchingToken;
     }


### PR DESCRIPTION
## Description
When the `showAuthFailureReason` is set to true, it's expected to show an error message, when the account is locked. This works fine when only the SMS OTP is configured in the second step. However, when it's configured with any other authenticator (ex: Email OTP), it allows the user to try SMS OTP continuously and an error page is not shown.

## Related Issue
- https://github.com/wso2/product-is/issues/14868

## Related PR
- https://github.com/wso2/identity-apps/pull/3488