### PR TITLE
[U2] [5.11] Changing failed account lockout and unlock time calculation approach

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1533,7 +1533,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         Map<String, String> updatedClaims = new HashMap<>();
         if ((currentAttempts + 1) >= maxAttempts) {
             // Calculate the incremental unlock-time-interval in milli seconds.
-            if (context.getProperty(SMSOTPConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null) {
+            if (context.getProperty(SMSOTPConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT) != null &&
+                context.getProperty(SMSOTPConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT)
+                        instanceof Integer) {
                 int overallLockoutCount =
                         (int) context.getProperty(SMSOTPConstants.OVERALL_FAILED_LOGIN_LOCKOUT_COUNT);
                 unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1551,8 +1551,6 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             updatedClaims.put(SMSOTPConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
             updatedClaims.put(SMSOTPConstants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
             updatedClaims.put(SMSOTPConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
-            // updatedClaims.put(SMSOTPConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-            //         String.valueOf(failedLoginLockoutCountValue + 1));
             updatedClaims.put(SMSOTPConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
                     SMSOTPConstants.MAX_SMS_OTP_ATTEMPTS_EXCEEDED);
             IdentityUtil.threadLocalProperties.get().put(SMSOTPConstants.ADMIN_INITIATED, false);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -139,6 +139,7 @@ public class SMSOTPConstants {
     public static final String ADMIN_INITIATED = "AdminInitiated";
 
     public static final String MAX_SMS_OTP_ATTEMPTS_EXCEEDED = "MAX_SMS_OTP_ATTEMPTS_EXCEEDED";
+    public static final String OVERALL_FAILED_LOGIN_LOCKOUT_COUNT = "overallFailedLoginLockoutCount";
 
     /**
      * Enums for error messages.


### PR DESCRIPTION
Changes on calculating unlock time and failed login lockout count using temporary context variable.

Related issue: https://github.com/wso2/product-is/issues/14928