### PR TITLE
[3.0.x] Add support for fully customized SMS with $ctx.otp

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -984,7 +984,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         smsUrl.setDisplayName("SMS URL");
         smsUrl.setRequired(false);
         smsUrl.setDescription("Enter client sms url value. If the phone number and text message are in URL, " +
-                "specify them as $ctx.num and $ctx.msg");
+                "specify them as $ctx.num and $ctx.msg or $ctx.otp");
         smsUrl.setDisplayOrder(0);
         configProperties.add(smsUrl);
 
@@ -1001,7 +1001,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         headers.setDisplayName("HTTP Headers");
         headers.setRequired(false);
         headers.setDescription("Enter the headers used by the API separated by comma, with the Header name and value " +
-                "separated by \":\". If the phone number and text message are in Headers, specify them as $ctx.num and $ctx.msg");
+                "separated by \":\". If the phone number and text message are in Headers, specify them as $ctx.num " +
+                "and $ctx.msg or $ctx.otp");
         headers.setDisplayOrder(2);
         configProperties.add(headers);
 
@@ -1010,7 +1011,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         payload.setDisplayName("HTTP Payload");
         payload.setRequired(false);
         payload.setDescription("Enter the HTTP Payload used by the SMS API. If the phone number and text message are " +
-                "in Payload, specify them as $ctx.num and $ctx.msg");
+                "in Payload, specify them as $ctx.num and $ctx.msg or $ctx.otp");
         payload.setDisplayOrder(3);
         configProperties.add(payload);
 
@@ -1072,8 +1073,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 if (log.isDebugEnabled()) {
                     log.debug("Processing HTTP headers since header string is available");
                 }
-                headerString = headerString.trim().replaceAll("\\$ctx.num", receivedMobileNumber).replaceAll(
-                        "\\$ctx.msg", smsMessage + otpToken);
+                headerString = replacePlaceholders(headerString.trim(), otpToken, receivedMobileNumber, smsMessage);
                 headerArray = headerString.split(",");
                 for (String header : headerArray) {
                     String[] headerElements = header.split(":");
@@ -1121,8 +1121,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                             encodedMobileNo = receivedMobileNumber;
                         }
                     }
-                    payload = payload.replaceAll("\\$ctx.num", encodedMobileNo).replaceAll("\\$ctx.msg",
-                            encodedSMSMessage + otpToken);
+                    payload = replacePlaceholders(payload, otpToken, encodedMobileNo, encodedSMSMessage);
                     OutputStreamWriter writer = null;
                     try {
                         writer = new OutputStreamWriter(httpConnection.getOutputStream(), SMSOTPConstants.CHAR_SET_UTF_8);
@@ -1261,8 +1260,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         boolean connection;
         String smsMessage = SMSOTPConstants.SMS_MESSAGE;
         String receivedMobileNumber = URLEncoder.encode(mobile, CHAR_SET_UTF_8);
-        smsUrl = smsUrl.replaceAll("\\$ctx.num", receivedMobileNumber).replaceAll("\\$ctx.msg",
-                smsMessage.replaceAll("\\s", "+") + otpToken);
+
+        String encodedSmsMessage = smsMessage.replaceAll("\\s", "+");
+        smsUrl = replacePlaceholders(smsUrl, otpToken, receivedMobileNumber, encodedSmsMessage);
         URL smsProviderUrl = null;
         try {
             smsProviderUrl = new URL(smsUrl);
@@ -1284,6 +1284,21 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         connection = getConnection(httpConnection, context, headerString, payload, httpResponse, mobile,
                 smsMessage, otpToken, httpMethod);
         return connection;
+    }
+
+    /**
+     * Replace the placeholders with their actual values in the request payload.
+     *
+     * @param payload       Message payload with placeholders
+     * @param otpToken      Generated OTP token
+     * @param mobileNumber  Mobile phone number
+     * @param message       Message content (without OTP)
+     * @return  Message payload string after populating actual values for the placeholders
+     */
+    private String replacePlaceholders(String payload, String otpToken, String mobileNumber, String message) {
+        return payload.replaceAll("\\$ctx.num", mobileNumber)
+                .replaceAll("\\$ctx.msg", message + otpToken)
+                .replaceAll("\\$ctx.otp", otpToken);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Port the improvement done in https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/117 https://github.com/wso2/product-is/issues/12555 to 3.0.x