### PR TITLE
[2.0.x] Update identity governance version

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -159,7 +159,7 @@
                             javax.servlet.http,
                             org.wso2.carbon.extension.identity.helper.*;
                             version="${identity.extension.utils.import.version.range}",
-                            org.wso2.carbon.identity.governance.service.notification;
+                            org.wso2.carbon.identity.governance.*;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.service;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
     <properties>
         <carbon.identity.version>5.15.47</carbon.identity.version>
         <carbon.identity.version.range>[5.11.0,5.13.0)</carbon.identity.version.range>
-        <identity.governance.version>1.1.37</identity.governance.version>
+        <identity.governance.version>1.3.26</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.1.37, 2.0.0)</identity.governance.imp.pkg.version.range>
         <commons-logging.version>4.4.11</commons-logging.version>
         <carbon.kernel.version>4.4.35</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
This PR bumps the identity governance version to the version where the fix [1] is introduced. It fixes the build failure occurred with [2].

[1] https://github.com/wso2-extensions/identity-governance/blob/master/components/org.wso2.carbon.identity.governance/src/main/java/org/wso2/carbon/identity/governance/service/notification/NotificationChannels.java#L32
[2] https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/169