### PR TITLE
[2.0.x] Update kernel version

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -155,6 +155,8 @@
                             version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.utils.*;
                             version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.*;
+                            version="${carbon.kernel.imp.pkg.version.range}",
                             javax.servlet,
                             javax.servlet.http,
                             org.wso2.carbon.extension.identity.helper.*;

--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <identity.governance.version>1.3.26</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.1.37, 2.0.0)</identity.governance.imp.pkg.version.range>
         <commons-logging.version>4.4.11</commons-logging.version>
-        <carbon.kernel.version>4.4.35</carbon.kernel.version>
+        <carbon.kernel.version>4.5.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0,5.0.0)</carbon.kernel.imp.pkg.version.range>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>


### PR DESCRIPTION
## Purpose
After updating the carbon-identity-framework version in [1], jenkins build is failing with the following error without running tests. Hence, need to bump the kernel version where the `UserStorePreferenceOrderSupplier` is introduced.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project org.wso2.carbon.extension.identity.authenticator.smsotp.connector: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test failed: There was an error in the forked process
[ERROR] java.lang.IllegalStateException: Failed to transform class with name org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils. Reason: org.wso2.carbon.user.core.config.UserStorePreferenceOrderSupplier
[ERROR] at org.powermock.core.classloader.MockClassLoader.loadMockClass(MockClassLoader.java:283)
[ERROR] at org.powermock.core.classloader.MockClassLoader.loadModifiedClass(MockClassLoader.java:192)
```

[1] https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/169