### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/OneTimePassword.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/OneTimePassword.java
@@ -86,13 +86,13 @@ public class OneTimePassword {
     /**
      * This method uses the JCE to provide the HMAC-SHA-1
      * algorithm. HMAC computes a Hashed Message Authentication Code and in this
-     * case SHA1 is the hash algorithm used.
+     * case SHA256 is the hash algorithm used.
      *
-     * @param keyBytes the bytes to use for the HMAC-SHA-1 key
+     * @param keyBytes the bytes to use for the HMAC-SHA-256 key
      * @param text     the message or text to be authenticated.
-     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
 
     public static byte[] hmacShaGenerate(byte[] keyBytes, byte[] text) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -123,9 +123,9 @@ public class OneTimePassword {
      *                         will be used. Dynamic truncation is when the last 4 bits of
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
-     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                      int truncationOffset) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -174,9 +174,9 @@ public class OneTimePassword {
      *                         will be used. Dynamic truncation is when the last 4 bits of
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
-     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException if no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateAlphaNumericOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                                  int truncationOffset) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -223,7 +223,7 @@ public class OneTimePassword {
             try {
                 return generateAlphaNumericOTP(key.getBytes(), Long.parseLong(base), digits, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
-                throw new AuthenticationFailedException(" Unable to find the SHA1 Algorithm to generate OTP ", e);
+                throw new AuthenticationFailedException(" Unable to find the SHA256 Algorithm to generate OTP ", e);
             } catch (InvalidKeyException e) {
                 throw new AuthenticationFailedException(" Unable to find the secret key ", e);
             }
@@ -231,7 +231,7 @@ public class OneTimePassword {
             try {
                 return generateOTP(key.getBytes(), Long.parseLong(base), digits, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
-                throw new AuthenticationFailedException(" Unable to find the SHA1 Algorithm to generate OTP ", e);
+                throw new AuthenticationFailedException(" Unable to find the SHA256 Algorithm to generate OTP ", e);
             } catch (InvalidKeyException e) {
                 throw new AuthenticationFailedException(" Unable to find the secret key ", e);
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -28,9 +28,9 @@ public class SMSOTPConstants {
     private static final String SMSOTP_PREFIX = "SMSOTP-";
     public static final String AUTHENTICATOR_NAME = "SMSOTP";
     public static final String AUTHENTICATOR_FRIENDLY_NAME = "SMS OTP";
-    public static final String ALGORITHM_NAME = "SHA1PRNG";
-    public static final String ALGORITHM_HMAC = "HmacSHA1";
-    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-1";
+    public static final String ALGORITHM_NAME = "DRBG";
+    public static final String ALGORITHM_HMAC = "HmacSHA256";
+    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-256";
     public static final String CHAR_SET_UTF_8 = "UTF-8";
 
     public static final int SECRET_KEY_LENGTH = 5;

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/OnetimePasswordTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/OnetimePasswordTest.java
@@ -76,13 +76,13 @@ public class OnetimePasswordTest {
     public void testGenerateTokenWithNumericToken() throws Exception {
         OneTimePassword otp = PowerMockito.spy(oneTimePassword);
         Assert.assertEquals(Whitebox.invokeMethod(otp, "generateToken", "Hello", "32", 10, false),
-                "0701282405");
+                "0020315280");
     }
 
     @Test
     public void testGenerateTokenWithAlphaNumericToken() throws Exception {
         OneTimePassword otp = PowerMockito.spy(oneTimePassword);
         Assert.assertEquals(Whitebox.invokeMethod(otp, "generateToken", "Hello", "32", 10, true),
-                "IWYTV8DJ31");
+                "3FDC3J6089");
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -27,9 +27,9 @@ import java.util.List;
  */
 public class Constants {
 
-    public static final String ALGORITHM_NAME = "SHA1PRNG";
-    public static final String ALGORITHM_HMAC = "HmacSHA1";
-    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-1";
+    public static final String ALGORITHM_NAME = "DRBG";
+    public static final String ALGORITHM_HMAC = "HmacSHA256";
+    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-256";
     public static final String SESSION_TYPE_OTP = "SMS_OTP";
 
     public static final int NUMBER_BASE = 2;

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/OneTimePasswordUtils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/OneTimePasswordUtils.java
@@ -86,15 +86,15 @@ public class OneTimePasswordUtils {
     }
 
     /**
-     * This method uses the JCE to provide the HMAC-SHA-1
+     * This method uses the JCE to provide the HMAC-SHA-256
      * algorithm. HMAC computes a Hashed Message Authentication Code and in this
-     * case SHA1 is the hash algorithm used.
+     * case SHA256 is the hash algorithm used.
      *
-     * @param keyBytes Bytes to use for the HMAC-SHA-1 key.
+     * @param keyBytes Bytes to use for the HMAC-SHA-256 key.
      * @param text     Message or text to be authenticated.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static byte[] hmacShaGenerate(byte[] keyBytes, byte[] text) throws NoSuchAlgorithmException,
             InvalidKeyException {
@@ -125,9 +125,9 @@ public class OneTimePasswordUtils {
      *                         will be used. Dynamic truncation is when the last 4 bits of
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                      int truncationOffset) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -176,9 +176,9 @@ public class OneTimePasswordUtils {
      *                         will be used. Dynamic truncation is when the last 4 bits of
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateAlphaNumericOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                                  int truncationOffset)
@@ -229,7 +229,7 @@ public class OneTimePasswordUtils {
                 return generateAlphaNumericOTP(key.getBytes(), Long.parseLong(base), length, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_ALPHA_NUMERIC_OTP_ERROR,
-                        "Unable to find the SHA1 Algorithm to generate OTP.", e);
+                        "Unable to find the SHA256 Algorithm to generate OTP.", e);
             } catch (InvalidKeyException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_ALPHA_NUMERIC_OTP_ERROR,
                         "Unable to find the secret key.", e);
@@ -239,7 +239,7 @@ public class OneTimePasswordUtils {
                 return generateOTP(key.getBytes(), Long.parseLong(base), length, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_OTP_ERROR,
-                        "Unable to find the SHA1 Algorithm to generate OTP.", e);
+                        "Unable to find the SHA256 Algorithm to generate OTP.", e);
             } catch (InvalidKeyException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_OTP_ERROR,
                         "Unable to find the secret key.", e);

--- a/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/OneTimePasswordUtilsTest.java
+++ b/component/common/src/test/java/org/wso2/carbon/identity/smsotp/common/test/OneTimePasswordUtilsTest.java
@@ -88,7 +88,7 @@ public class OneTimePasswordUtilsTest {
                 String.valueOf(Constants.NUMBER_BASE),
                 Constants.DEFAULT_OTP_LENGTH,
                 false),
-                "900361");
+                "673418");
     }
 
     @Test
@@ -100,6 +100,6 @@ public class OneTimePasswordUtilsTest {
                 String.valueOf(Constants.NUMBER_BASE),
                 Constants.DEFAULT_OTP_LENGTH,
                 true),
-                "W5GG7P");
+                "2B0A7V");
     }
 }


### PR DESCRIPTION
## Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- Random number will be generated using DRBG algorithm instead of SHA1PRNG.
- OTP will be generated using HMACSHA256.

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717


