### PR TITLE
Provided Tenant Qualified URL Support for SMS OTP

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -73,6 +73,14 @@
             <artifactId>org.wso2.carbon.identity.event</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -88,6 +88,7 @@ public class SMSOTPConstants {
     public static final String SMS_LOGIN_PAGE = "authenticationendpoint/smsOtp.jsp";
     public static final String RETRY_PARAMS = "&authFailure=true&authFailureMsg=authentication.fail.message";
     public static final String ERROR_PAGE = "authenticationendpoint/smsOtpError.jsp";
+    public static final String MOBILE_NO_REQ_PAGE = "authenticationendpoint/mobile.jsp";
     public static final String MOBILE_NUMBER_REQ_PAGE = "MobileNumberRegPage";
     public static final String MOBILE_NUMBER = "MOBILE_NUMBER";
     public static final String REQUESTED_USER_MOBILE = "requestedUserMobile";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -249,4 +249,20 @@ public class SMSOTPConstants {
             return ErrorMessage.SERVER_UNKNOWN_ERROR;
         }
     }
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String OUTBOUND_AUTH_SMSOTP_SERVICE = "outbound-auth-sms-otp";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String SEND_SMS_OTP = "send-sms-otp";
+        }
+    }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -55,6 +55,7 @@ import org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants;
 import org.wso2.carbon.identity.authenticator.smsotp.SMSOTPUtils;
 import org.wso2.carbon.identity.authenticator.smsotp.exception.SMSOTPException;
 import org.wso2.carbon.identity.authenticator.smsotp.internal.SMSOTPServiceDataHolder;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
@@ -91,7 +92,7 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ConfigurationFacade.class, SMSOTPUtils.class, FederatedAuthenticatorUtil.class, FrameworkUtils.class,
-        IdentityTenantUtil.class, SMSOTPServiceDataHolder.class, ServiceURLBuilder.class})
+        IdentityTenantUtil.class, SMSOTPServiceDataHolder.class, ServiceURLBuilder.class, LoggerUtils.class})
 @PowerMockIgnore({"org.wso2.carbon.identity.application.common.model.User", "org.mockito.*", "javax.servlet.*"})
 public class SMSOTPAuthenticatorTest {
     
@@ -145,6 +146,8 @@ public class SMSOTPAuthenticatorTest {
         when(httpServletRequest.getHeaderNames()).thenReturn(requestHeaders);
         initMocks(this);
         mockServiceURLBuilder();
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
     }
 
     @AfterMethod
@@ -781,8 +784,8 @@ public class SMSOTPAuthenticatorTest {
         PowerMockito.when(ServiceURLBuilder.create()).thenReturn(builder);
     }
 
-    @DataProvider(name = "mobileNoReqDataProvider")
-    public static Object[][] getMobileNoReqPageData() {
+    @DataProvider(name = "mobileNumberRequestDataProvider")
+    public static Object[][] getMobileNumberRequestPageData() {
 
         return new Object[][]{
 
@@ -812,8 +815,8 @@ public class SMSOTPAuthenticatorTest {
         };
     }
 
-    @Test(dataProvider = "mobileNoReqDataProvider")
-    public void testGetMobileNoReqPage(boolean isTenantQualifiedURLEnabled,
+    @Test(dataProvider = "mobileNumberRequestDataProvider")
+    public void testGetMobileNumberRequestPage(boolean isTenantQualifiedURLEnabled,
                                        String tenantDomain, String urlFromConfig,
                                        String expectedURL) throws Exception {
 
@@ -838,7 +841,7 @@ public class SMSOTPAuthenticatorTest {
         PowerMockito.when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedURLEnabled);
         PowerMockito.when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomain);
 
-        Assert.assertEquals(Whitebox.invokeMethod(smsotpAuthenticator, "getMobileNoReqPage",
+        Assert.assertEquals(Whitebox.invokeMethod(smsotpAuthenticator, "getMobileNumberRequestPage",
                 context), expectedURL);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.ui</artifactId>
                 <version>${carbon.kernel.version}</version>
@@ -288,6 +293,12 @@
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
@@ -456,10 +467,12 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.version>5.23.28</carbon.identity.version>
+        <carbon.identity.version>5.25.338</carbon.identity.version>
         <identity.governance.version>1.4.1</identity.governance.version>
         <carbon.identity.event.version>5.18.206</carbon.identity.event.version>
         <carbon.identity.version.range>[5.16.0,7.0.0)</carbon.identity.version.range>
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
         <commons-logging.version>4.4.11</commons-logging.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/10947

This PR adds support to resolve tenant qualified URL when SMS OTP portal is externalized.

When the tenant qualified URLs feature is enabled

1. If the URL externalized (or customized) is a relative one (ie. hosted within IS with a different context than default), then build the URL with tenant qualified path (/t/{tenantDomain} in the path)
2. If the URL externalized is an absolute one, then we do not try to tenant qualify it.
3. If no URLs are defined from configs, then build the tenant qualified URLs with the default context

Related issue: https://github.com/wso2/product-is/issues/10953
