### PR TITLE
Add configuration to handle backup codes as an identity claim

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -40,6 +40,9 @@ public class SMSOTPConstants {
     public static final String CODE = "OTPcode";
     public static final String MOBILE_CLAIM = "http://wso2.org/claims/mobile";
     public static final String SAVED_OTP_LIST = "http://wso2.org/claims/otpbackupcodes";
+    public static final String OTP_BACKUP_CODES_IDENTITY_CLAIM = "http://wso2.org/claims/identity/otpbackupcodes";
+    public static final String HANDLE_BACKUP_CODES_AS_IDENTITY_CLAIM = "OTPBackupCodes.UseIdentityClaims";
+    public static final String BACKUP_CODES_SEPARATOR = ",";
     public static final String USER_SMSOTP_DISABLED_CLAIM_URI = "http://wso2.org/claims/identity/smsotp_disabled";
     public static final String SMS_OTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -584,8 +584,8 @@ public class SMSOTPAuthenticatorTest {
         stepConfig.setSubjectAttributeStep(true);
         stepConfig.setAuthenticatedUser(authenticatedUser);
         context.setProperty(SMSOTPConstants.CODE_MISMATCH, false);
-        context.setProperty(SMSOTPConstants.OTP_TOKEN, "123456");
-        context.setProperty(SMSOTPConstants.TOKEN_VALIDITY_TIME, "");
+        context.setProperty(SMSOTPConstants.OTP_TOKEN,"123456");
+        context.setProperty(SMSOTPConstants.TOKEN_VALIDITY_TIME,"");
         Map<String, String> parameters = new HashMap<>();
         AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
         authenticatorConfig.setParameterMap(parameters);
@@ -649,61 +649,13 @@ public class SMSOTPAuthenticatorTest {
                 httpServletRequest, httpServletResponse, context);
     }
 
-    @Test
-    public void testProcessAuthenticationResponseWithValidBackupCodeInIdentityClaim() throws Exception {
-
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(SMSOTPUtils.class);
-        when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("123456");
-        context.setProperty(SMSOTPConstants.OTP_TOKEN, "123456");
-        context.setProperty(SMSOTPConstants.USER_NAME, "admin");
-        Map<String, String> parameters = new HashMap<>();
-        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
-        authenticatorConfig.setParameterMap(parameters);
-        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
-        authenticatedUser.setAuthenticatedSubjectIdentifier("admin");
-        authenticatedUser.setUserName("admin");
-        authenticatedUser.setTenantDomain("carbon.super");
-        setStepConfigWithSmsOTPAuthenticator(authenticatorConfig, authenticatedUser, context);
-        when(smsotpAuthenticator.getAuthenticatedUser(context)).thenReturn(authenticatedUser);
-        when((AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER)).thenReturn(authenticatedUser);
-        when(SMSOTPUtils.getBackupCode(context)).thenReturn("true");
-
-        when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
-        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
-        when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
-        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
-        when(userStoreManager.getUserClaimValues(anyString(),
-                eq(new String[]{SMSOTPConstants.OTP_BACKUP_CODES_IDENTITY_CLAIM}), anyString()))
-                .thenReturn(Collections.singletonMap(SMSOTPConstants.OTP_BACKUP_CODES_IDENTITY_CLAIM, "123456,789123"));
-        mockStatic(FrameworkUtils.class);
-        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
-
-        mockStatic(IdentityUtil.class);
-        when(IdentityUtil.getProperty(SMSOTPConstants.HANDLE_BACKUP_CODES_AS_IDENTITY_CLAIM)).thenReturn("true");
-
-        Property property = new Property();
-        property.setName(SMSOTPConstants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE);
-        property.setValue("true");
-        when(SMSOTPUtils.getAccountLockConnectorConfigs(authenticatedUser.getTenantDomain()))
-                .thenReturn(new Property[]{property});
-        when(SMSOTPUtils.isLocalUser(context)).thenReturn(true);
-        when(userStoreManager.getClaimManager()).thenReturn(claimManager);
-        when(userStoreManager.getClaimManager().getClaim(SMSOTPConstants.OTP_BACKUP_CODES_IDENTITY_CLAIM))
-                .thenReturn(claim);
-        when(context.getProperty(SMSOTPConstants.CODE_MISMATCH)).thenReturn(false);
-
-        Whitebox.invokeMethod(smsotpAuthenticator, "processAuthenticationResponse",
-                httpServletRequest, httpServletResponse, context);
-    }
-
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testProcessAuthenticationResponseWithCodeMismatch() throws Exception {
         mockStatic(SMSOTPUtils.class);
         mockStatic(IdentityTenantUtil.class);
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("123456");
-        context.setProperty(SMSOTPConstants.OTP_TOKEN, "123");
-        context.setProperty(SMSOTPConstants.USER_NAME, "admin");
+        context.setProperty(SMSOTPConstants.OTP_TOKEN,"123");
+        context.setProperty(SMSOTPConstants.USER_NAME,"admin");
         Map<String, String> parameters = new HashMap<>();
         AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
         authenticatorConfig.setParameterMap(parameters);
@@ -732,7 +684,7 @@ public class SMSOTPAuthenticatorTest {
     @Test
     public void testCheckWithBackUpCodes() throws Exception {
         mockStatic(IdentityTenantUtil.class);
-        context.setProperty(SMSOTPConstants.USER_NAME, "admin");
+        context.setProperty(SMSOTPConstants.USER_NAME,"admin");
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
@@ -751,16 +703,16 @@ public class SMSOTPAuthenticatorTest {
                 .thenReturn(Collections.singletonMap(SMSOTPConstants.SAVED_OTP_LIST, "12345,4568,1234,7896"));
         AuthenticatedUser user = (AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER);
         mockStatic(FrameworkUtils.class);
-        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
+        when (FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
         Whitebox.invokeMethod(smsotpAuthenticator, "checkWithBackUpCodes",
-                context, "1234", user);
+                context,"1234",user);
     }
 
     public void testCheckWithInvalidBackUpCodes() throws Exception {
 
         mockStatic(IdentityTenantUtil.class);
         mockStatic(SMSOTPUtils.class);
-        context.setProperty(SMSOTPConstants.USER_NAME, "admin");
+        context.setProperty(SMSOTPConstants.USER_NAME,"admin");
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
@@ -775,7 +727,7 @@ public class SMSOTPAuthenticatorTest {
         setStepConfigWithSmsOTPAuthenticator(authenticatorConfig, authenticatedUser, context);
         when((AuthenticatedUser) context.getProperty(SMSOTPConstants.AUTHENTICATED_USER)).thenReturn(authenticatedUser);
         mockStatic(FrameworkUtils.class);
-        when(FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
+        when (FrameworkUtils.getMultiAttributeSeparator()).thenReturn(",");
         when(userRealm.getUserStoreManager()
                 .getUserClaimValues(MultitenantUtils.getTenantAwareUsername("admin"),
                         new String[]{SMSOTPConstants.SAVED_OTP_LIST}, null))
@@ -795,16 +747,15 @@ public class SMSOTPAuthenticatorTest {
         when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userRealm.getUserStoreManager()
-                .getUserClaimValue("admin", "http://wso2.org/claims/mobile", null))
-                .thenReturn("0778965231");
+                .getUserClaimValue("admin", "http://wso2.org/claims/mobile", null)).thenReturn("0778965231");
         when(SMSOTPUtils.getNoOfDigits(context)).thenReturn("4");
 
         // with forward order
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "0778******");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"0778******");
 
         // with backward order
         when(SMSOTPUtils.getDigitsOrder(context)).thenReturn("backward");
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "******5231");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context,userRealm,"admin"),"******5231");
     }
 
     @Test
@@ -824,13 +775,11 @@ public class SMSOTPAuthenticatorTest {
         when(SMSOTPUtils.getNoOfDigits(context)).thenReturn("4");
 
         // with forward order
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"),
-                "0778******");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "0778******");
 
         // with backward order
         when(SMSOTPUtils.getDigitsOrder(context)).thenReturn("backward");
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"),
-                "******9889");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "******9889");
     }
 
     @Test(expectedExceptions = {SMSOTPException.class})
@@ -840,7 +789,7 @@ public class SMSOTPAuthenticatorTest {
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(-1234)).thenReturn(null);
         Whitebox.invokeMethod(smsotpAuthenticator, "updateMobileNumberForUsername",
-                context, httpServletRequest, "admin", "carbon.super");
+                context,httpServletRequest,"admin","carbon.super");
     }
 
     @Test

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -149,22 +149,15 @@ public class SMSOTPAuthenticatorTest {
     @Mock
     private FrameworkServiceDataHolder frameworkServiceDataHolder;
 
-    @Mock
-    private ClaimManager claimManager;
-    @Mock
-    private Claim claim;
-    @Mock
-    private SMSOTPServiceDataHolder sMSOTPServiceDataHolder;
-    @Mock
-    private IdentityEventService identityEventService;
-    @Mock
-    private Enumeration<String> requestHeaders;
-    @Mock
-    private AuthenticatedUser authenticatedUser;
+    @Mock private ClaimManager claimManager;
+    @Mock private Claim claim;
+    @Mock private SMSOTPServiceDataHolder sMSOTPServiceDataHolder;
+    @Mock private IdentityEventService identityEventService;
+    @Mock private Enumeration<String> requestHeaders;
+    @Mock private AuthenticatedUser authenticatedUser;
 
     @BeforeMethod
     public void setUp() throws Exception {
-
         smsotpAuthenticator = new SMSOTPAuthenticator();
         mockStatic(FileBasedConfigurationBuilder.class);
         mockStatic(FrameworkServiceDataHolder.class);
@@ -185,26 +178,22 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetFriendlyName() {
-
         Assert.assertEquals(smsotpAuthenticator.getFriendlyName(), SMSOTPConstants.AUTHENTICATOR_FRIENDLY_NAME);
     }
 
     @Test
     public void testGetName() {
-
         Assert.assertEquals(smsotpAuthenticator.getName(), SMSOTPConstants.AUTHENTICATOR_NAME);
     }
 
     @Test
     public void testRetryAuthenticationEnabled() throws Exception {
-
         SMSOTPAuthenticator smsotp = PowerMockito.spy(smsotpAuthenticator);
         Assert.assertTrue((Boolean) Whitebox.invokeMethod(smsotp, "retryAuthenticationEnabled"));
     }
 
     @Test
     public void testGetContextIdentifierPassed() {
-
         when(httpServletRequest.getParameter(FrameworkConstants.SESSION_DATA_KEY)).thenReturn
                 ("0246893");
         Assert.assertEquals(smsotpAuthenticator.getContextIdentifier(httpServletRequest), "0246893");
@@ -212,7 +201,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCanHandleTrue() {
-
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn(null);
         when(httpServletRequest.getParameter(SMSOTPConstants.RESEND)).thenReturn("resendCode");
         Assert.assertEquals(smsotpAuthenticator.canHandle(httpServletRequest), true);
@@ -220,7 +208,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCanHandleFalse() {
-
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn(null);
         when(httpServletRequest.getParameter(SMSOTPConstants.RESEND)).thenReturn(null);
         when(httpServletRequest.getParameter(SMSOTPConstants.MOBILE_NUMBER)).thenReturn(null);
@@ -229,7 +216,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetURL() throws Exception {
-
         SMSOTPAuthenticator smsotp = PowerMockito.spy(smsotpAuthenticator);
         Assert.assertEquals(Whitebox.invokeMethod(smsotp, "getURL",
                         SMSOTPConstants.LOGIN_PAGE, null),
@@ -238,7 +224,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetURLwithQueryParams() throws Exception {
-
         SMSOTPAuthenticator smsotp = PowerMockito.spy(smsotpAuthenticator);
         Assert.assertEquals(Whitebox.invokeMethod(smsotp, "getURL",
                         SMSOTPConstants.LOGIN_PAGE, "n=John&n=Susan"),
@@ -248,7 +233,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetMobileNumber() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         when(SMSOTPUtils.getMobileNumberForUsername(anyString())).thenReturn("0775968325");
         Assert.assertEquals(Whitebox.invokeMethod(smsotpAuthenticator, "getMobileNumber",
@@ -258,7 +242,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testRedirectToErrorPage() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         AuthenticationContext authenticationContext = new AuthenticationContext();
         when(SMSOTPUtils.getErrorPageFromXMLFile(authenticationContext))
@@ -272,7 +255,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testRedirectToMobileNumberReqPage() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         AuthenticationContext authenticationContext = new AuthenticationContext();
         when(SMSOTPUtils.isEnableMobileNoUpdate(authenticationContext)).thenReturn(true);
@@ -287,7 +269,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCheckStatusCode() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         context.setProperty(SMSOTPConstants.STATUS_CODE, "");
         when(SMSOTPUtils.isRetryEnabled(context)).thenReturn(true);
@@ -302,7 +283,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCheckStatusCodeWithNullValue() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         context.setProperty(SMSOTPConstants.STATUS_CODE, null);
         when(SMSOTPUtils.isRetryEnabled(context)).thenReturn(true);
@@ -317,7 +297,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCheckStatusCodeWithMismatch() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         context.setProperty(SMSOTPConstants.CODE_MISMATCH, "true");
         when(SMSOTPUtils.isRetryEnabled(context)).thenReturn(false);
@@ -333,7 +312,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCheckStatusCodeWithTokenExpired() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         context.setProperty(SMSOTPConstants.TOKEN_EXPIRED, "token.expired");
         when(SMSOTPUtils.isEnableResendCode(context)).thenReturn(true);
@@ -349,7 +327,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testProcessSMSOTPFlow() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         mockStatic(ConfigurationFacade.class);
         when(SMSOTPUtils.isSMSOTPDisableForLocalUser("John", context)).thenReturn(true);
@@ -633,7 +610,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testProcessAuthenticationResponseWithValidBackupCode() throws Exception {
-
         mockStatic(IdentityTenantUtil.class);
         mockStatic(SMSOTPUtils.class);
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("123456");
@@ -723,7 +699,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testProcessAuthenticationResponseWithCodeMismatch() throws Exception {
-
         mockStatic(SMSOTPUtils.class);
         mockStatic(IdentityTenantUtil.class);
         when(httpServletRequest.getParameter(SMSOTPConstants.CODE)).thenReturn("123456");
@@ -756,7 +731,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testCheckWithBackUpCodes() throws Exception {
-
         mockStatic(IdentityTenantUtil.class);
         context.setProperty(SMSOTPConstants.USER_NAME, "admin");
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
@@ -812,7 +786,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetScreenAttribute() throws UserStoreException, AuthenticationFailedException {
-
         mockStatic(IdentityTenantUtil.class);
         mockStatic(SMSOTPUtils.class);
         when(SMSOTPUtils.getScreenUserAttribute(context)).thenReturn
@@ -822,18 +795,16 @@ public class SMSOTPAuthenticatorTest {
         when(realmService.getTenantUserRealm(-1234)).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(userRealm.getUserStoreManager()
-                .getUserClaimValue("admin", "http://wso2.org/claims/mobile", null)).thenReturn(
-                "0778965231");
+                .getUserClaimValue("admin", "http://wso2.org/claims/mobile", null))
+                .thenReturn("0778965231");
         when(SMSOTPUtils.getNoOfDigits(context)).thenReturn("4");
 
         // with forward order
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"),
-                "0778******");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "0778******");
 
         // with backward order
         when(SMSOTPUtils.getDigitsOrder(context)).thenReturn("backward");
-        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"),
-                "******5231");
+        Assert.assertEquals(smsotpAuthenticator.getScreenAttribute(context, userRealm, "admin"), "******5231");
     }
 
     @Test
@@ -864,7 +835,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test(expectedExceptions = {SMSOTPException.class})
     public void testUpdateMobileNumberForUsername() throws Exception {
-
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId("carbon.super")).thenReturn(-1234);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
@@ -875,7 +845,6 @@ public class SMSOTPAuthenticatorTest {
 
     @Test
     public void testGetConfigurationProperties() {
-
         List<Property> configProperties = new ArrayList<Property>();
         Property smsUrl = new Property();
         configProperties.add(smsUrl);
@@ -906,7 +875,6 @@ public class SMSOTPAuthenticatorTest {
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
-
         return new PowerMockObjectFactory();
     }
 


### PR DESCRIPTION
## Purpose
SMS OTP and TOTP backup codes are stored in the http://wso2.org/claims/otpbackupcodes claim. Ideally, it should be an identity claim

## Goals
>Persist backup codes in an identity claim
## Approach
> Add a deployment.toml configuration to enable treating the backup code claim as an identity claim

## Related PRs
* https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/173
*  https://github.com/wso2/carbon-identity-framework/pull/5155

## Related Issues
https://github.com/wso2-enterprise/wso2-iam-internal/issues/942
https://github.com/wso2/product-is/issues/17252