### PR TITLE
Redirect to error page if user does not exist

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -199,6 +199,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 }
             } else {
                 log.debug("The user does not exist in the user stores.");
+                String queryParams = FrameworkUtils.getQueryStringWithFrameworkContextId(context.getQueryParams(),
+                        context.getCallerSessionKey(), context.getContextIdentifier());
+                redirectToErrorPage(response, context, queryParams, SMSOTPConstants.ERROR_USER_NOT_FOUND);
                 return AuthenticatorFlowStatus.INCOMPLETE;
             }
         } else if (Boolean.parseBoolean(request.getParameter(RESEND))) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -123,6 +123,7 @@ public class SMSOTPConstants {
     public static final String ERROR_SMSOTP_DISABLE = "&authFailure=true&authFailureMsg=smsotp.disable";
     public static final String ERROR_SMSOTP_DISABLE_MSG = "smsotp.disable";
     public static final String SEND_OTP_DIRECTLY_DISABLE = "&authFailure=true&authFailureMsg=directly.send.otp.disable";
+    public static final String ERROR_USER_NOT_FOUND = "&authFailure=true&authFailureMsg=error.user.not.found.smsotp";
     public static final String SEND_OTP_DIRECTLY_DISABLE_MSG = "directly.send.otp.disable";
     public static final String ERROR_CODE_MISMATCH = "code.mismatch";
     public static final String ERROR_CODE = "errorCode";


### PR DESCRIPTION
## Purpose
User is currently redirected to an empty page when user does not exist. This fix is to redirect the user to the sms otp error page.

## Related Issue

- https://github.com/wso2/product-is/issues/17527

## Related PR

- https://github.com/wso2/identity-apps/pull/4682