### PR TITLE
Skip triggering mobile number verification during SMS OTP flow

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -64,6 +64,8 @@ import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.governance.service.notification.NotificationChannels;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -1197,6 +1199,11 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 Object verifiedMobileObject = context.getProperty(SMSOTPConstants.REQUESTED_USER_MOBILE);
                 if (verifiedMobileObject != null) {
                     try {
+                        if (Utils.getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate() != null) {
+                            Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
+                        }
+                        Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(IdentityRecoveryConstants.
+                                SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_SMS_OTP_FLOW.toString());
                         updateMobileNumberForUsername(context, request, username, tenantDomain);
                     } catch (SMSOTPException e) {
                         throw new AuthenticationFailedException("Failed accessing the userstore for user: " + username, e.getCause());
@@ -1210,6 +1217,8 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                             context.setProperty(SMSOTPConstants.PROFILE_UPDATE_FAILURE_REASON, ex.getMessage());
                         }
                         throw new AuthenticationFailedException("Mobile claim update failed for user " + username, e);
+                    } finally {
+                        Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
                     }
                 }
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1199,9 +1199,6 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 Object verifiedMobileObject = context.getProperty(SMSOTPConstants.REQUESTED_USER_MOBILE);
                 if (verifiedMobileObject != null) {
                     try {
-                        if (Utils.getThreadLocalToSkipSendingSmsOtpVerificationOnUpdate() != null) {
-                            Utils.unsetThreadLocalToSkipSendingSmsOtpVerificationOnUpdate();
-                        }
                         Utils.setThreadLocalToSkipSendingSmsOtpVerificationOnUpdate(IdentityRecoveryConstants.
                                 SkipMobileNumberVerificationOnUpdateStates.SKIP_ON_SMS_OTP_FLOW.toString());
                         updateMobileNumberForUsername(context, request, username, tenantDomain);

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.25.450</carbon.identity.version>
-        <identity.governance.version>1.8.84</identity.governance.version>
+        <identity.governance.version>1.8.101</identity.governance.version>
         <carbon.identity.event.version>5.18.206</carbon.identity.event.version>
         <carbon.identity.version.range>[5.16.0,7.0.0)</carbon.identity.version.range>
         <org.wso2.carbon.identity.organization.management.core.version>1.0.0


### PR DESCRIPTION
### Proposed changes in this pull request

- Skip triggering an SMS OTP verification, when the mobile number was updated by user during the SMS OTP flow at the first login where the mobile number is not previously set. At the moment mobile number was already verified during the SMS OTP verification. So no need to verify it again.

### Related Issue

- https://github.com/wso2/product-is/issues/18414

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/795
