### PR TITLE
Fix runtime import failure

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -137,6 +137,7 @@
                             org.wso2.carbon.identity.governance.service.notification;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.version.range}",
+                            org.wso2.carbon.identity.core; version="${carbon.identity.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",


### PR DESCRIPTION
Fix runtime import failure that happens when framework version is bumped into 7.x.x

Related to https://github.com/wso2/product-is/issues/19176