### PR TITLE
Get authenticator name through its own function.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -394,12 +394,10 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
             String mobile = null;
             StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
             String previousStepAuthenticator = stepConfig.getAuthenticatedAutenticator().getName();
-            StepConfig currentStep = context.getSequenceConfig().getStepMap().get(context.getCurrentStep());
-            String currentStepAuthenticator = currentStep.getAuthenticatorList().iterator().next().getName();
             if (sendOtpToFederatedMobile) {
                 federatedMobileAttributeKey = getFederatedMobileAttributeKey(context, previousStepAuthenticator);
                 if (StringUtils.isEmpty(federatedMobileAttributeKey)) {
-                    federatedMobileAttributeKey = getFederatedMobileAttributeKey(context, currentStepAuthenticator);
+                    federatedMobileAttributeKey = getFederatedMobileAttributeKey(context, getName());
                 }
                 Map<ClaimMapping, String> userAttributes = context.getCurrentAuthenticatedIdPs().values().
                         iterator().next().getUser().getUserAttributes();


### PR DESCRIPTION
## Purpose
> In the SMSOTPAuthenticator, the authenticator name is retrieved through the authenticators of the current step. This has caused inconsistencies when both emailOTP and smsOTP are configured in the same step. However inside the SMSOTPAuthenticator class it is not necessary to read the authenticator name through current step since the authenticator is itself. 
This PR fixes this issue by retrieving the name of the authenticator by its own `getName()` function. 

## Relate Issue 
https://github.com/wso2/product-is/issues/19482