### PR TITLE
Set missing display name property to Auth Initiation Data

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -2609,6 +2609,7 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
 
         AuthenticatorData authenticatorData = new AuthenticatorData();
         authenticatorData.setName(getName());
+        authenticatorData.setDisplayName(getFriendlyName());
         String idpName = null;
         AuthenticatedUser authenticatedUser = null;
         if (context != null && context.getExternalIdP() != null) {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/smsotp/test/SMSOTPAuthenticatorTest.java
@@ -1125,6 +1125,8 @@ public class SMSOTPAuthenticatorTest {
         authenticatorParamMetadataList.add(usernameMetadata);
 
         Assert.assertEquals(authenticatorDataObj.getName(), SMSOTPConstants.AUTHENTICATOR_NAME);
+        Assert.assertEquals(authenticatorDataObj.getDisplayName(), SMSOTPConstants.AUTHENTICATOR_FRIENDLY_NAME,
+                "Authenticator display name should match.");
         Assert.assertEquals(authenticatorDataObj.getAuthParams().size(), authenticatorParamMetadataList.size(),
                 "Size of lists should be equal.");
         Assert.assertEquals(authenticatorDataObj.getPromptType(),


### PR DESCRIPTION
Fixes the issue of not having the display name property in the auth initiation data during api based autehntication.

Related issue: https://github.com/wso2/product-is/issues/20219