### PR TITLE
 Fix StringIndexOutOfBoundsException in SMS OTP

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1903,6 +1903,11 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
         String hiddenScreenValue;
 
         int screenAttributeLength = screenUserAttributeValue.length();
+        // Ensure noOfDigits is not greater than screenAttributeLength.
+        noOfDigits = Math.min(noOfDigits, screenAttributeLength);
+        if (screenAttributeLength <= noOfDigits && log.isDebugEnabled()) {
+            log.debug("Mobile number length is less than or equal to noOfDigits: " + noOfDigits);
+        }
         if (SMSOTPConstants.BACKWARD.equals(SMSOTPUtils.getDigitsOrder(context))) {
             screenValue = screenUserAttributeValue.substring(screenAttributeLength - noOfDigits,
                     screenAttributeLength);


### PR DESCRIPTION
## Purpose
> Fix StringIndexOutOfBoundsException in SMS OTP. Here noOfDigits is the numbers we show on screen for a particular mobile number. The issue arises when mobile_no<noOfDigits. In that case, we show the whole mobile number.


## Related Issue

> https://github.com/wso2/product-is/issues/20191