### PR TITLE
Implement mobile number masking capability with a regex

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -145,6 +145,8 @@
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -1901,6 +1901,12 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
 
         String screenValue;
         String hiddenScreenValue;
+        String maskingRegex = SMSOTPUtils.getScreenValueRegex(context);
+
+        if (StringUtils.isNotEmpty(maskingRegex)) {
+            screenValue = screenUserAttributeValue.replaceAll(maskingRegex, SMSOTPConstants.SCREEN_VALUE_MASKING_CHARACTER);
+            return screenValue;
+        }
 
         int screenAttributeLength = screenUserAttributeValue.length();
         // Ensure noOfDigits is not greater than screenAttributeLength.

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -134,7 +134,7 @@ public class SMSOTPConstants {
     public static final String NO_DIGITS = "noOfDigits";
     public static final String ORDER = "order";
     public static final String BACKWARD = "backward";
-    public static final String SCREEN_VALUE_REGEX = "screenValueMaskRegex";
+    public static final String SCREEN_VALUE_REGEX = "screenUserAttributeMaskRegex";
     public static final String SCREEN_VALUE_MASKING_CHARACTER = "*";
     public static final String SCREEN_VALUE = "&screenvalue=";
     public static final String CODE_MISMATCH = "codeMismatch";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -134,6 +134,8 @@ public class SMSOTPConstants {
     public static final String NO_DIGITS = "noOfDigits";
     public static final String ORDER = "order";
     public static final String BACKWARD = "backward";
+    public static final String SCREEN_VALUE_REGEX = "screenValueMaskRegex";
+    public static final String SCREEN_VALUE_MASKING_CHARACTER = "*";
     public static final String SCREEN_VALUE = "&screenvalue=";
     public static final String CODE_MISMATCH = "codeMismatch";
     public static final String ACCOUNT_LOCKED = "accountLocked";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
@@ -552,4 +552,15 @@ public class SMSOTPUtils {
         return Boolean
                 .parseBoolean(getConfiguration(context, SMSOTPConstants.ENABLE_PAYLOAD_ENCODING_FOR_SMS_OTP));
     }
+
+    /**
+     * Get the regex masking the screen value.
+     *
+     * @param context Authentication context.
+     * @return regex for masking screen value.
+     */
+    public static String getScreenValueRegex(AuthenticationContext context) {
+
+        return getConfiguration(context, SMSOTPConstants.SCREEN_VALUE_REGEX);
+    }
 }


### PR DESCRIPTION
## Purpose
$subject

Regex can be provided as follows;
```
[authentication.authenticator.sms_otp.parameters]
screenUserAttribute = "http://wso2.org/claims/mobile"
screenUserAttributeMaskRegex='(?&lt;=\d{2})\d(?=\d{2})'
```
Output (If the mobile number is configured as +94776565656):
![Screenshot 2024-05-16 at 11 26 34 PM](https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/assets/37938529/cfc3caa6-b3f2-4d05-bad6-3536c35f8526)

## Related issues
- https://github.com/wso2/product-is/issues/20221
- https://github.com/wso2/product-is/issues/20415