### PR TITLE
Add account lock capability to SMS OTP Service

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -102,6 +102,8 @@
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.store;
                                 version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event;
                                 version="${carbon.identity.package.import.version.range}",
@@ -109,6 +111,7 @@
                                 version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.services;
                                 version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.service.notification;
                                 version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.internal;
@@ -118,7 +121,11 @@
                             org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.constants;
                                 version="${carbon.kernel.package.import.version.range}",
-                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}"
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.exception;
+                                version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service;
+                                version="${carbon.identity.account.lock.handler.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.smsotp.common.internal,

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -56,6 +56,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY;
+
 /**
  * This class implements the SMSOTPService interface.
  */
@@ -401,6 +406,10 @@ public class SMSOTPServiceImpl implements SMSOTPService {
     /**
      * Execute account lock flow for OTP verification failures.
      *
+     * @param userId            The ID of the user.
+     * @param showFailureReason Display the failure reason.
+     * @return The response DTO.
+     * @throws SMSOTPException If an error occurs while handling the account lock.
      */
     private ValidationResponseDTO handleAccountLock(String userId, boolean showFailureReason)
             throws SMSOTPException {
@@ -412,10 +421,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
 
         User user = getUserById(userId);
         if (Utils.isAccountLocked(user)) {
-            FailureReasonDTO error = showFailureReason
-                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, userId)
-                    : null;
-            return new ValidationResponseDTO(userId, false, error);
+            return createAccountLockedResponse(userId, showFailureReason);
         }
 
         int maxAttempts = 0;
@@ -425,21 +431,21 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
         for (Property connectorConfig : connectorConfigs) {
             switch (connectorConfig.getName()) {
-                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                case ACCOUNT_LOCKED_PROPERTY:
                     if (!Boolean.parseBoolean(connectorConfig.getValue())) {
                         return null;
                     }
-                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+                case FAILED_LOGIN_ATTEMPTS_PROPERTY:
                     if (NumberUtils.isNumber(connectorConfig.getValue())) {
                         maxAttempts = Integer.parseInt(connectorConfig.getValue());
                     }
                     break;
-                case Constants.PROPERTY_ACCOUNT_LOCK_TIME:
+                case ACCOUNT_UNLOCK_TIME_PROPERTY:
                     if (NumberUtils.isNumber(connectorConfig.getValue())) {
                         unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
                     }
                     break;
-                case Constants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+                case LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY:
                     if (NumberUtils.isNumber(connectorConfig.getValue())) {
                         double value = Double.parseDouble(connectorConfig.getValue());
                         if (value > 0) {
@@ -454,41 +460,60 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         if (claimValues == null) {
             claimValues = new HashMap<>();
         }
-        int currentAttempts = 0;
-        if (NumberUtils.isNumber(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM))) {
-            currentAttempts = Integer.parseInt(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM));
-        }
-        int failedLoginLockoutCountValue = 0;
-        if (NumberUtils.isNumber(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
-            failedLoginLockoutCountValue =
-                    Integer.parseInt(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
-        }
+        int currentAttempts = getCurrentAttempts(claimValues);
+        int failedLoginLockoutCountValue = getFailedLoginLockoutCount(claimValues);
 
         Map<String, String> updatedClaims = new HashMap<>();
         if ((currentAttempts + 1) >= maxAttempts) {
-            // Calculate the incremental unlock time interval in milli seconds.
-            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
-                    failedLoginLockoutCountValue));
-            // Calculate unlock time by adding current time and unlock time interval in milli seconds.
-            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
-            updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
-            updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
-            updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
-            updatedClaims.put(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
-                    String.valueOf(failedLoginLockoutCountValue + 1));
-            updatedClaims.put(Constants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
-                    Constants.MAX_SMS_OTP_ATTEMPTS_EXCEEDED);
-            IdentityUtil.threadLocalProperties.get().put(Constants.ADMIN_INITIATED, false);
+            populateAccountLockClaims(unlockTimePropertyValue, unlockTimeRatio, failedLoginLockoutCountValue, updatedClaims);
             setUserClaimValues(user, updatedClaims);
-            FailureReasonDTO error = showFailureReason
-                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, userId)
-                    : null;
-            return new ValidationResponseDTO(userId, false, error);
+            return createAccountLockedResponse(userId, showFailureReason);
         } else {
             updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
             setUserClaimValues(user, updatedClaims);
             return null;
         }
+    }
+
+    private ValidationResponseDTO createAccountLockedResponse(String userId, boolean showFailureReason) {
+
+        FailureReasonDTO error = showFailureReason ?
+                new FailureReasonDTO(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, userId) : null;
+        return new ValidationResponseDTO(userId, false, error);
+    }
+
+    private void populateAccountLockClaims(long unlockTimePropertyValue, double unlockTimeRatio,
+                                           int failedLoginLockoutCountValue, Map<String, String> updatedClaims) {
+
+        // Calculate the incremental unlock time interval in milli seconds.
+        unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+                failedLoginLockoutCountValue));
+        // Calculate unlock time by adding current time and unlock time interval in milli seconds.
+        long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+        updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+        updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+        updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+        updatedClaims.put(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+                String.valueOf(failedLoginLockoutCountValue + 1));
+        updatedClaims.put(Constants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
+                Constants.MAX_SMS_OTP_ATTEMPTS_EXCEEDED);
+        IdentityUtil.threadLocalProperties.get().put(Constants.ADMIN_INITIATED, false);
+    }
+
+    private int getCurrentAttempts(Map<String, String> claimValues) {
+
+        if (NumberUtils.isNumber(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            return Integer.parseInt(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM));
+        }
+        return 0;
+    }
+
+    private int getFailedLoginLockoutCount(Map<String, String> claimValues) {
+
+        if (NumberUtils.isNumber(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
+            return Integer.parseInt(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
+        }
+        return 0;
     }
 
     private User getUserById(String userId) throws SMSOTPException {
@@ -516,7 +541,6 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             return userStoreManager.getUserClaimValues(user.getDomainQualifiedUsername(), claims,
                     UserCoreConstants.DEFAULT_PROFILE);
         } catch (UserStoreException e) {
-            log.error("Error while reading user claims.", e);
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
                     String.format("Failed to read user claims for user ID : %s.", user.getUserID()), e);
         }
@@ -530,7 +554,6 @@ public class SMSOTPServiceImpl implements SMSOTPService {
             userStoreManager.setUserClaimValues(user.getDomainQualifiedUsername(), updatedClaims,
                     UserCoreConstants.DEFAULT_PROFILE);
         } catch (UserStoreException e) {
-            log.error("Error while updating user claims", e);
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
                     String.format("Failed to update user claims for user ID: %s.", user.getUserID()), e);
         }
@@ -552,7 +575,7 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
         // Return if account lock handler is not enabled.
         for (Property connectorConfig : connectorConfigs) {
-            if ((Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
+            if ((ACCOUNT_LOCKED_PROPERTY.equals(connectorConfig.getName())) &&
                     !Boolean.parseBoolean(connectorConfig.getValue())) {
                 return;
             }
@@ -584,7 +607,6 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         } catch (UserStoreException e) {
             String errorMessage = String.format("Failed to reset failed attempts count for user ID : %s.",
                     user.getUserID());
-            log.error(errorMessage, e);
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
                     errorMessage, e);
         }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -20,12 +20,15 @@ package org.wso2.carbon.identity.smsotp.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -172,17 +175,23 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         }
         // Valid OTP. Clear OTP session data.
         SessionDataStore.getInstance().clearSessionData(sessionId, Constants.SESSION_TYPE_OTP);
+        resetOtpFailedAttempts(userId);
         return new ValidationResponseDTO(userId, true);
     }
 
     private ValidationResponseDTO isValid(SessionDTO sessionDTO, String smsOTP, String userId,
-                                          String transactionId, int validateAttempt, boolean showFailureReason) {
+                                          String transactionId, int validateAttempt, boolean showFailureReason)
+            throws SMSOTPException {
 
         FailureReasonDTO error;
         // Check if the provided OTP is correct.
         if (!StringUtils.equals(smsOTP, sessionDTO.getOtp())) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Invalid OTP provided for the user : %s.", userId));
+            }
+            ValidationResponseDTO responseDTO = handleAccountLock(userId, showFailureReason);
+            if (responseDTO != null) {
+                return responseDTO;
             }
             int remainingFailedAttempts =
                     SMSOTPServiceDataHolder.getConfigs().getMaxValidationAttemptsAllowed() - validateAttempt;
@@ -387,5 +396,197 @@ public class SMSOTPServiceImpl implements SMSOTPService {
 
         return StringUtils.isBlank(MDC.get(Constants.CORRELATION_ID_MDC))
                 ? UUID.randomUUID().toString() : MDC.get(Constants.CORRELATION_ID_MDC);
+    }
+
+    /**
+     * Execute account lock flow for OTP verification failures.
+     *
+     */
+    private ValidationResponseDTO handleAccountLock(String userId, boolean showFailureReason)
+            throws SMSOTPException {
+
+        boolean lockAccountOnFailedAttempts = SMSOTPServiceDataHolder.getConfigs().isLockAccountOnFailedAttempts();
+        if (!lockAccountOnFailedAttempts) {
+            return null;
+        }
+
+        User user = getUserById(userId);
+        if (Utils.isAccountLocked(user)) {
+            FailureReasonDTO error = showFailureReason
+                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, userId)
+                    : null;
+            return new ValidationResponseDTO(userId, false, error);
+        }
+
+        int maxAttempts = 0;
+        long unlockTimePropertyValue = 0;
+        double unlockTimeRatio = 1;
+
+        Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
+        for (Property connectorConfig : connectorConfigs) {
+            switch (connectorConfig.getName()) {
+                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                    if (!Boolean.parseBoolean(connectorConfig.getValue())) {
+                        return null;
+                    }
+                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        maxAttempts = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case Constants.PROPERTY_ACCOUNT_LOCK_TIME:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case Constants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        double value = Double.parseDouble(connectorConfig.getValue());
+                        if (value > 0) {
+                            unlockTimeRatio = value;
+                        }
+                    }
+                    break;
+            }
+        }
+        Map<String, String> claimValues = getUserClaimValues(user, new String[]{
+                Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM});
+        if (claimValues == null) {
+            claimValues = new HashMap<>();
+        }
+        int currentAttempts = 0;
+        if (NumberUtils.isNumber(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            currentAttempts = Integer.parseInt(claimValues.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM));
+        }
+        int failedLoginLockoutCountValue = 0;
+        if (NumberUtils.isNumber(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
+            failedLoginLockoutCountValue =
+                    Integer.parseInt(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
+        }
+
+        Map<String, String> updatedClaims = new HashMap<>();
+        if ((currentAttempts + 1) >= maxAttempts) {
+            // Calculate the incremental unlock time interval in milli seconds.
+            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+                    failedLoginLockoutCountValue));
+            // Calculate unlock time by adding current time and unlock time interval in milli seconds.
+            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+            updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+            updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+            updatedClaims.put(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+                    String.valueOf(failedLoginLockoutCountValue + 1));
+            updatedClaims.put(Constants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
+                    Constants.MAX_SMS_OTP_ATTEMPTS_EXCEEDED);
+            IdentityUtil.threadLocalProperties.get().put(Constants.ADMIN_INITIATED, false);
+            setUserClaimValues(user, updatedClaims);
+            FailureReasonDTO error = showFailureReason
+                    ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, userId)
+                    : null;
+            return new ValidationResponseDTO(userId, false, error);
+        } else {
+            updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
+            setUserClaimValues(user, updatedClaims);
+            return null;
+        }
+    }
+
+    private User getUserById(String userId) throws SMSOTPException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) SMSOTPServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            return userStoreManager.getUser(userId, null);
+        } catch (UserStoreException e) {
+            // Handle user not found.
+            String errorCode = ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode();
+            if (UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode().equals(errorCode)) {
+                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_INVALID_USER_ID, userId);
+            }
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Error while retrieving user for the ID : %s.", userId), e);
+        }
+    }
+
+    private Map<String, String> getUserClaimValues(User user, String[] claims) throws SMSOTPServerException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) SMSOTPServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            return userStoreManager.getUserClaimValues(user.getDomainQualifiedUsername(), claims,
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while reading user claims.", e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Failed to read user claims for user ID : %s.", user.getUserID()), e);
+        }
+    }
+
+    private void setUserClaimValues(User user, Map<String, String> updatedClaims) throws SMSOTPServerException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) SMSOTPServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            userStoreManager.setUserClaimValues(user.getDomainQualifiedUsername(), updatedClaims,
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while updating user claims", e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Failed to update user claims for user ID: %s.", user.getUserID()), e);
+        }
+    }
+
+    /**
+     * Reset OTP Failed Attempts count upon successful completion of the OTP verification.
+     *
+     * @param userId The ID of the user.
+     * @throws SMSOTPException If an error occurred.
+     */
+    private void resetOtpFailedAttempts(String userId) throws SMSOTPException {
+
+        if (!SMSOTPServiceDataHolder.getConfigs().isLockAccountOnFailedAttempts()) {
+            return;
+        }
+
+        User user = getUserById(userId);
+        Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
+        // Return if account lock handler is not enabled.
+        for (Property connectorConfig : connectorConfigs) {
+            if ((Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
+                    !Boolean.parseBoolean(connectorConfig.getValue())) {
+                return;
+            }
+        }
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) SMSOTPServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+
+            String[] claimsToCheck = {Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, Constants.ACCOUNT_LOCKED_CLAIM};
+            Map<String, String> userClaims = userStoreManager.getUserClaimValues(user.getDomainQualifiedUsername(),
+                    claimsToCheck, UserCoreConstants.DEFAULT_PROFILE);
+            String failedEmailOtpAttemptsClaimValue = userClaims.get(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM);
+            String accountLockClaimValue = userClaims.get(Constants.ACCOUNT_LOCKED_CLAIM);
+
+            Map<String, String> updatedClaims = new HashMap<>();
+            if (NumberUtils.isNumber(failedEmailOtpAttemptsClaimValue) &&
+                    Integer.parseInt(failedEmailOtpAttemptsClaimValue) > 0) {
+                updatedClaims.put(Constants.SMS_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            }
+            if (Boolean.parseBoolean(accountLockClaimValue)) {
+                updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+                updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, "0");
+            }
+            if (!updatedClaims.isEmpty()) {
+                userStoreManager.setUserClaimValues(user.getDomainQualifiedUsername(), updatedClaims,
+                        UserCoreConstants.DEFAULT_PROFILE);
+            }
+        } catch (UserStoreException e) {
+            String errorMessage = String.format("Failed to reset failed attempts count for user ID : %s.",
+                    user.getUserID());
+            log.error(errorMessage, e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    errorMessage, e);
+        }
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -49,6 +49,20 @@ public class Constants {
     public static final String SMS_OTP_RESEND_THROTTLE_INTERVAL = "smsOtp.resendThrottleInterval";
     public static final String SMS_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED = "smsOtp.maxValidationAttemptsAllowed";
     public static final String SMS_OTP_SHOW_FAILURE_REASON = "smsOtp.showValidationFailureReason";
+    public static final String SMS_OTP_LOCK_ACCOUNT_ON_FAILED_ATTEMPTS = "smsOtp.lockAccountOnFailedAttempts";
+
+    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
+    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+    public static final String SMS_OTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
+    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
+            "http://wso2.org/claims/identity/failedLoginLockoutCount";
+    public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
+    public static final String ACCOUNT_LOCKED_REASON_CLAIM_URI = "http://wso2.org/claims/identity/lockedReason";
+    public static final String MAX_SMS_OTP_ATTEMPTS_EXCEEDED = "MAX_SMS_OTP_ATTEMPTS_EXCEEDED";
+    public static final String ADMIN_INITIATED = "AdminInitiated";
 
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
     public static final String CORRELATION_ID = "correlation-id";
@@ -72,12 +86,13 @@ public class Constants {
                 "Mandatory parameters not found : %s."),
         CLIENT_OTP_VALIDATION_FAILED("SMS-60008", "Provided OTP is invalid.",
                 "Provided OTP is invalid. User id : %s."),
-        CLIENT_NO_OTP_FOR_USER("SMS-60009", "No OTP fround for the user.",
+        CLIENT_NO_OTP_FOR_USER("SMS-60009", "No OTP found for the user.",
                 "No OTP found for the user Id : %s."),
         CLIENT_SLOW_DOWN_RESEND("SMS-60010", "Slow down.",
                 "Please wait %s seconds before retrying."),
         CLIENT_OTP_VALIDATION_BLOCKED("SMS-60011", "Maximum allowed failed validation attempts exceeded.",
                 "Maximum allowed failed validation attempts exceeded for user id : %s."),
+        CLIENT_ACCOUNT_LOCKED("SMS-60012", "Account locked.", "Account is locked for the user ID: %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("SMS-65001", "User store manager error.",
@@ -99,7 +114,11 @@ public class Constants {
         SERVER_INVALID_RENEWAL_INTERVAL_ERROR("SMS-65009", "Invalid renewal interval value.",
                 "Renewal interval should be smaller than the OTP validity period. Renewal interval: %s."),
         SERVER_UNEXPECTED_ERROR("SMS-65010", "An unexpected server error occurred.",
-                "An unexpected server error occurred.");
+                "An unexpected server error occurred."),
+        SERVER_ERROR_VALIDATING_ACCOUNT_LOCK_STATUS("SMS-65011", "Error validating account lock status.",
+                "Server encountered an error while validating account lock status for the user ID : %s."),
+        SERVER_ERROR_RETRIEVING_ACCOUNT_LOCK_CONFIGS("SMS-65012", "Can't retrieve account lock connector " +
+                "configurations.", "Server encountered an error while retrieving account lock connector configurations.");
 
         private final String code;
         private final String message;

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -51,10 +51,6 @@ public class Constants {
     public static final String SMS_OTP_SHOW_FAILURE_REASON = "smsOtp.showValidationFailureReason";
     public static final String SMS_OTP_LOCK_ACCOUNT_ON_FAILED_ATTEMPTS = "smsOtp.lockAccountOnFailedAttempts";
 
-    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
-    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
-    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
-    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
     public static final String SMS_OTP_FAILED_ATTEMPTS_CLAIM = "http://wso2.org/claims/identity/failedSmsOtpAttempts";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
             "http://wso2.org/claims/identity/failedLoginLockoutCount";

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/dto/ConfigsDTO.java
@@ -34,6 +34,7 @@ public class ConfigsDTO {
     private int otpRenewalInterval;
     private int resendThrottleInterval;
     private int maxValidationAttemptsAllowed;
+    private boolean lockAccountOnFailedAttempts;
 
     public boolean isEnabled() {
 
@@ -145,6 +146,16 @@ public class ConfigsDTO {
         this.maxValidationAttemptsAllowed = maxValidationAttemptsAllowed;
     }
 
+    public boolean isLockAccountOnFailedAttempts() {
+
+        return lockAccountOnFailedAttempts;
+    }
+
+    public void setLockAccountOnFailedAttempts(boolean lockAccountOnFailedAttempts) {
+
+        this.lockAccountOnFailedAttempts = lockAccountOnFailedAttempts;
+    }
+
     @Override
     public String toString() {
 
@@ -160,6 +171,7 @@ public class ConfigsDTO {
                 .append(",\n\totpRenewalInterval = ").append(otpRenewalInterval)
                 .append(",\n\tresendThrottleInterval = ").append(resendThrottleInterval)
                 .append(",\n\tmaxValidationAttemptsAllowed = ").append(maxValidationAttemptsAllowed)
+                .append(",\n\tlockAccountOnFailedAttempts = ").append(lockAccountOnFailedAttempts)
                 .append("\n}");
         return sb.toString();
     }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/internal/SMSOTPServiceComponent.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/internal/SMSOTPServiceComponent.java
@@ -28,6 +28,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.smsotp.common.SMSOTPService;
 import org.wso2.carbon.identity.smsotp.common.SMSOTPServiceImpl;
 import org.wso2.carbon.identity.smsotp.common.util.Utils;
@@ -97,5 +99,39 @@ public class SMSOTPServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("Setting the Event Service.");
         }
+    }
+
+    @Reference(
+            name = "AccountLockService",
+            service = org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountLockService"
+    )
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        SMSOTPServiceDataHolder.getInstance().setAccountLockService(null);
+    }
+
+    @Reference(
+            name = "IdentityGovernanceService",
+            service = org.wso2.carbon.identity.governance.IdentityGovernanceService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityGovernanceService"
+    )
+    protected void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
+    }
+
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        SMSOTPServiceDataHolder.getInstance().setIdentityGovernanceService(null);
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/internal/SMSOTPServiceDataHolder.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/internal/SMSOTPServiceDataHolder.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.smsotp.common.internal;
 
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.identity.smsotp.common.dto.ConfigsDTO;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -28,6 +30,8 @@ public class SMSOTPServiceDataHolder {
 
     private static final SMSOTPServiceDataHolder dataHolder = new SMSOTPServiceDataHolder();
     private RealmService realmService;
+    private AccountLockService accountLockService;
+    private IdentityGovernanceService identityGovernanceService;
     private static final ConfigsDTO configs = new ConfigsDTO();
 
     public static SMSOTPServiceDataHolder getInstance() {
@@ -48,5 +52,45 @@ public class SMSOTPServiceDataHolder {
     public static ConfigsDTO getConfigs() {
 
         return configs;
+    }
+
+    /**
+     * Get Account Lock service.
+     *
+     * @return Account Lock service.
+     */
+    public AccountLockService getAccountLockService() {
+
+        return accountLockService;
+    }
+
+    /**
+     * Set Account Lock service.
+     *
+     * @param accountLockService Account Lock service.
+     */
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+
+    /**
+     * Get Identity Governance service.
+     *
+     * @return Identity Governance service.
+     */
+    public IdentityGovernanceService getIdentityGovernanceService() {
+
+        return identityGovernanceService;
+    }
+
+    /**
+     * Set Identity Governance service.
+     *
+     * @param identityGovernanceService Identity Governance service.
+     */
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        this.identityGovernanceService = identityGovernanceService;
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -38,6 +38,11 @@ import org.wso2.carbon.user.core.common.User;
 import java.util.Properties;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY;
+
 /**
  * Util functions for SMS OTP service.
  */
@@ -236,9 +241,8 @@ public class Utils {
 
         try {
             return SMSOTPServiceDataHolder.getInstance().getIdentityGovernanceService().getConfiguration
-                    (new String[]{Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE,
-                            Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX, Constants.PROPERTY_ACCOUNT_LOCK_TIME,
-                            Constants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO}, tenantDomain);
+                    (new String[]{ACCOUNT_LOCKED_PROPERTY, FAILED_LOGIN_ATTEMPTS_PROPERTY, ACCOUNT_UNLOCK_TIME_PROPERTY,
+                            LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY}, tenantDomain);
         } catch (IdentityGovernanceException e) {
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_ERROR_RETRIEVING_ACCOUNT_LOCK_CONFIGS, null,
                     e);

--- a/docs/sms_otp_service.md
+++ b/docs/sms_otp_service.md
@@ -28,15 +28,22 @@ properties.tokenRenewalInterval=60
 properties.resendThrottleInterval=30
 # Set the maximum validation attempts allowed until the generated sms-otp expires.
 properties.maxValidationAttemptsAllowed=5
+# Lock the account after reaching the maximum number of failed login attempts.
+properties.lockAccountOnFailedAttempts = true
 ```
-4. If notifications are managed by the Identity Server, configure the **SMS template** by appending below at the end of
+
+   **NOTE:** If `properties.lockAccountOnFailedAttempts` is set to `true`, at tenant level it is required to enable 
+   the account lock capability and configure other properties such as unlock time duration.
+   For more details, refer to the documentation: https://is.docs.wso2.com/en/5.11.0/learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking
+
+5. If notifications are managed by the Identity Server, configure the **SMS template** by appending below at the end of
    the `<IS_HOME>/repository/conf/sms/sms-templates-admin-config.xml` file.
 ```xml
     <configuration type="sendOTP" display="sendOTP" locale="en_US">
         <body>Your One Time Password is : {{confirmation-code}}</body>
     </configuration>
 ```
-5. If notifications are managed by the Identity Server, configure the **event publisher** by creating 
+6. If notifications are managed by the Identity Server, configure the **event publisher** by creating 
    `SMSPublisher.xml` file in the `<IS_HOME>/deployment/server/eventpublishers/` directory.
    (Make sure to add a valid webhook endpoint in `http.url` section.)
 ```xml
@@ -53,7 +60,7 @@ properties.maxValidationAttemptsAllowed=5
     </to>
 </eventPublisher>
 ```
-6. Restart the server.
+7. Restart the server.
 
 **NOTE::** To include a **unique identification** in the **SMS template**, use the `correlation-id` variable in the 
 following syntax,


### PR DESCRIPTION
Locking the account on failed attempts is made configurable via deployment.toml file as shown in the example below.

```
[[event_handler]]
name= "smsOtp"
properties.enabled=true
properties.lockAccountOnFailedAttempts = true
```

In addition to this, at tenant level it is required to enable the account lock capability and configure other properties such as unlock time duration etc (https://is.docs.wso2.com/en/5.11.0/learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking).