### PR TITLE
Checking the user is resolved from a previous step

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -184,7 +184,11 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                     setResolvedUserInContext(context, authenticatedUser);
                 }
             } else if (isPreviousIdPAuthenticationFlowHandler(context)) {
-                authenticatedUser = resolveUserFromUserStore(authenticatedUser);
+                boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
+                // Resolve the user from user store if the user is not resolved in IDF handler.
+                if (!isUserResolved) {
+                    authenticatedUser = resolveUserFromUserStore(authenticatedUser);
+                }
                 setResolvedUserInContext(context, authenticatedUser);
             }
             if (authenticatedUser != null) {


### PR DESCRIPTION
## Purpose
- If IDF resolved the user from multi attribute login user resolving service, the `isUserResolved` property is set to true.
- This improvement is done to avoid user resolving again from the user store when the user is already resolved from the previous step.
- From this new changes, we only check for user when there is not `isUserResolved` in the context.

## Related PR
- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/162

## Related Issue
- https://github.com/wso2/product-is/issues/20466