### PR TITLE
[SMS-OTP] Handle showFailureReason disabled & account lock case in error response

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -124,6 +124,10 @@
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                                 version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.service;
                                 version="${carbon.identity.account.lock.handler.imp.pkg.version.range}"
                         </Import-Package>

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/SMSOTPServiceImpl.java
@@ -105,15 +105,17 @@ public class SMSOTPServiceImpl implements SMSOTPService {
         // Check if the user is locked.
         if (Utils.isAccountLocked(user)) {
             if (!showFailureReason) {
-                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_FORBIDDEN, user.getUserID());
+                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_GENERATION_NOT_VALID,
+                        user.getUserID());
             }
-            throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_FORBIDDEN, user.getUserID());
+            throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, user.getUserID());
         }
 
         // Check if the user is disabled.
         if (Utils.isUserDisabled(user)) {
             if (!showFailureReason) {
-                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_FORBIDDEN, user.getUserID());
+                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_OTP_GENERATION_NOT_VALID,
+                        user.getUserID());
             }
             throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_ACCOUNT_DISABLED, user.getUserID());
         }

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -91,8 +91,8 @@ public class Constants {
         CLIENT_ACCOUNT_LOCKED("SMS-60012", "Account locked.", "Account is locked for the user ID: %s."),
         CLIENT_ACCOUNT_DISABLED("SMS-60013", "Account disabled.",
                 "Account is disabled for the user ID: %s."),
-        CLIENT_FORBIDDEN("EMAIL-60014", "Forbidden.", "Forbidden : %s."),
-
+        CLIENT_OTP_GENERATION_NOT_VALID("SMS-60014", "OTP generation failed.",
+                "OTP Generation failed for the user : %s."),
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("SMS-65001", "User store manager error.",
                 "User store manager error : %s."),

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/constant/Constants.java
@@ -89,6 +89,9 @@ public class Constants {
         CLIENT_OTP_VALIDATION_BLOCKED("SMS-60011", "Maximum allowed failed validation attempts exceeded.",
                 "Maximum allowed failed validation attempts exceeded for user id : %s."),
         CLIENT_ACCOUNT_LOCKED("SMS-60012", "Account locked.", "Account is locked for the user ID: %s."),
+        CLIENT_ACCOUNT_DISABLED("SMS-60013", "Account disabled.",
+                "Account is disabled for the user ID: %s."),
+        CLIENT_FORBIDDEN("EMAIL-60014", "Forbidden.", "Forbidden : %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("SMS-65001", "User store manager error.",

--- a/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/identity/smsotp/common/util/Utils.java
@@ -22,7 +22,10 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.bean.ModuleConfiguration;
@@ -31,13 +34,20 @@ import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLock
 import org.wso2.carbon.identity.smsotp.common.constant.Constants;
 import org.wso2.carbon.identity.smsotp.common.dto.ConfigsDTO;
 import org.wso2.carbon.identity.smsotp.common.exception.SMSOTPClientException;
+import org.wso2.carbon.identity.smsotp.common.exception.SMSOTPException;
 import org.wso2.carbon.identity.smsotp.common.exception.SMSOTPServerException;
 import org.wso2.carbon.identity.smsotp.common.internal.SMSOTPServiceDataHolder;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ResidentIdpPropertyName.ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_PROPERTY;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
 import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
@@ -74,6 +84,55 @@ public class Utils {
         }
         log.debug(String.format("SMS OTP service configurations : %s.",
                 SMSOTPServiceDataHolder.getConfigs().toString()));
+    }
+
+    /**
+     *
+     * @param user
+     * @return
+     * @throws SMSOTPException
+     */
+    public static boolean isUserDisabled(User user) throws SMSOTPException {
+
+        try {
+            if (!isAccountDisablingEnabled(user.getTenantDomain())) {
+                return false;
+            }
+            String accountDisabledClaimValue = getClaimValue(
+                    user.getUserID(), ACCOUNT_DISABLED_CLAIM_URI, user.getTenantDomain());
+            return Boolean.parseBoolean(accountDisabledClaimValue);
+        } catch (FrameworkException e) {
+            throw new SMSOTPException(e.getErrorCode(), e.getMessage(), e);
+        }
+    }
+
+    private static boolean isAccountDisablingEnabled(String tenantDomain) throws FrameworkException {
+
+        Property accountDisableConfigProperty = FrameworkUtils.getResidentIdpConfiguration(
+                ACCOUNT_DISABLE_HANDLER_ENABLE_PROPERTY, tenantDomain);
+
+        return accountDisableConfigProperty != null && Boolean.parseBoolean(accountDisableConfigProperty.getValue());
+    }
+
+    private static String getClaimValue(String userId, String claimURI, String tenantDomain) throws
+            FrameworkException {
+
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) SMSOTPServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(tenantId).getUserStoreManager();
+
+            Map<String, String> values = userStoreManager.getUserClaimValuesWithID(userId, new String[]{claimURI},
+                    UserCoreConstants.DEFAULT_PROFILE);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("%s claim value of user %s is set to: " + values.get(claimURI),
+                        claimURI, userId));
+            }
+            return values.get(claimURI);
+
+        } catch (UserStoreException e) {
+            throw new FrameworkException("Error occurred while retrieving claim: " + claimURI, e);
+        }
     }
 
     /**


### PR DESCRIPTION
 Add account lock and disabled validation before OTP generation and validation.