### PR TITLE
Add maximum otp resend attempts validation 

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPAuthenticator.java
@@ -218,6 +218,9 @@ public class SMSOTPAuthenticator extends AbstractApplicationAuthenticator implem
                 return AuthenticatorFlowStatus.INCOMPLETE;
             }
         } else if (Boolean.parseBoolean(request.getParameter(RESEND))) {
+            if (!SMSOTPUtils.isEnableResendCode(context)) {
+                throw new InvalidCredentialsException("Resend code is not enabled for this authenticator");
+            }
             AuthenticatorFlowStatus authenticatorFlowStatus = super.process(request, response, context);
             publishPostSMSOTPGeneratedEvent(request, context);
             return authenticatorFlowStatus;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPConstants.java
@@ -65,6 +65,7 @@ public class SMSOTPConstants {
     public static final String BACKUP_CODE = "BackupCode";
     public static final String IS_ENABLED_RETRY = "RetryEnable";
     public static final String IS_ENABLED_RESEND = "ResendEnable";
+    public static final String MAXIMUM_RESEND_ATTEMPTS = "MaximumResendAttempts";
     public static final String IS_SMSOTP_MANDATORY = "SMSOTPMandatory";
     public static final String IS_SEND_OTP_DIRECTLY_TO_MOBILE = "SendOTPDirectlyToMobile";
     public static final String IS_SMSOTP_ENABLE_BY_USER = "SMSOTPEnableByUserClaim";
@@ -128,6 +129,7 @@ public class SMSOTPConstants {
     public static final String SEND_OTP_DIRECTLY_DISABLE = "&authFailure=true&authFailureMsg=directly.send.otp.disable";
     public static final String ERROR_USER_NOT_FOUND = "&authFailure=true&authFailureMsg=error.user.not.found.smsotp";
     public static final String SEND_OTP_DIRECTLY_DISABLE_MSG = "directly.send.otp.disable";
+    public static final String ERROR_USER_RESEND_COUNT_EXCEEDED = "&authFailure=true&authFailureMsg=resent.count.exceeded";
     public static final String ERROR_CODE_MISMATCH = "code.mismatch";
     public static final String ERROR_CODE = "errorCode";
     public static final String SCREEN_USER_ATTRIBUTE = "screenUserAttribute";
@@ -152,6 +154,7 @@ public class SMSOTPConstants {
     public static final String IS_SEND_OTP_TO_FEDERATED_MOBILE = "SendOtpToFederatedMobile";
     public static final String MOBILE_NUMBER_PATTERN_POLICY_VIOLATED =
             "Mobile number pattern policy violated";
+    public static final String OTP_RESEND_ATTEMPTS = "otpResendAttempts";
 
     public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
     public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/smsotp/SMSOTPUtils.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 public class SMSOTPUtils {
 
@@ -272,6 +273,33 @@ public class SMSOTPUtils {
     public static boolean isEnableResendCode(AuthenticationContext context) {
 
         return Boolean.parseBoolean(getConfiguration(context, SMSOTPConstants.IS_ENABLED_RESEND));
+    }
+
+    /**
+     * Retrieves the maximum resend attempts from the application-authentication.xml file.
+     * If the config is missing, returns an empty Optional indicating infinite retries are allowed.
+     *
+     * @param context AuthenticationContext.
+     * @return Optional containing the maximum resend attempts if configured; otherwise, empty.
+     * @throws SMSOTPException If the config is present but invalid (non-integer or negative).
+     */
+    public static Optional<Integer> getMaxResendAttempts(AuthenticationContext context) throws SMSOTPException {
+
+        String maximumResendAttemptsConfig = getConfiguration(context, SMSOTPConstants.MAXIMUM_RESEND_ATTEMPTS);
+        if (StringUtils.isBlank(maximumResendAttemptsConfig)) {
+            return Optional.empty();
+        }
+
+        try {
+            int maximumResendAttempts = Integer.parseInt(maximumResendAttemptsConfig);
+            if (maximumResendAttempts < 0) {
+                throw new NumberFormatException("Maximum resend attempts cannot be negative.");
+            }
+            return Optional.of(maximumResendAttempts);
+        } catch (NumberFormatException e) {
+            context.setRetrying(false);
+            throw new SMSOTPException("Invalid maximum resend attempts value: " + maximumResendAttemptsConfig, e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose

This PR will provide the support to validate the resend code attempts in the SMS OTP authenticator.
1. Maximum Resend attempts read from the application-authenticator.xml file
2. Update the context with the current resend code attempts of the user
3. Validate the user resend code attempts against the config and terminate the session if it is exceeded.

Also, 
`ResendEnable` config is not honoured in the sms otp resend flow in the BE.
Hence this PR will improve the logic to check the config before continuing the resend code flow in smsotp outbound authenticator.

## Related Issue
- https://github.com/wso2/product-is/issues/23890

